### PR TITLE
Remove obsolete mapping

### DIFF
--- a/src/logsearch-config/target/deployment_lookup.yml
+++ b/src/logsearch-config/target/deployment_lookup.yml
@@ -6,6 +6,5 @@ kibana.*: logsearch
 maintenance.*: logsearch
 parser.*: logsearch
 queue.*: logsearch
-router.*: logsearch
 monitor.*: logsearch
 ls-router.*: logsearch


### PR DESCRIPTION
There is no 'router' job in 'logsearch' deployment. Router is deployed as 'ls-router' job - this mapping already exists.