### PR TITLE
Check if deployment field is not set before parsing it using dictionary file

### DIFF
--- a/src/logsearch-config/src/logstash-filters/deployment.conf
+++ b/src/logsearch-config/src/logstash-filters/deployment.conf
@@ -1,4 +1,4 @@
-if [@source][job] {
+if ![@source][deployment] and [@source][job] {
   translate {
     field => "[@source][job]"
     dictionary_path => "/var/vcap/jobs/parser/config/deployment_lookup.yml"

--- a/src/logsearch-config/src/logstash-filters/snippets/monitor_filter.conf
+++ b/src/logsearch-config/src/logstash-filters/snippets/monitor_filter.conf
@@ -13,13 +13,15 @@ mutate {
   }
 }
 
-translate {
-  field => "[@source][job]"
-  destination => "[@source][deployment]"
-  regex => true
-  exact => true
-  dictionary_path => "/var/vcap/jobs/parser/config/deployment_lookup.yml"
-  fallback => "Unknown"
+if ![@source][deployment] {
+  translate {
+    field => "[@source][job]"
+    destination => "[@source][deployment]"
+    regex => true
+    exact => true
+    dictionary_path => "/var/vcap/jobs/parser/config/deployment_lookup.yml"
+    fallback => "Unknown"
+  }
 }
 
 if [@source][deployment] != "logsearch" {

--- a/src/logsearch-config/test/logstash-filters/deployment-spec.rb
+++ b/src/logsearch-config/test/logstash-filters/deployment-spec.rb
@@ -26,4 +26,20 @@ describe "@source.deployment lookup" do
       end
     end
   end
+
+  context "when there is [@source][deployment] set" do
+    when_parsing_log(
+        "@source" => { "deployment" => "deployment123", 
+                       "job" => "kibana-123123123" }
+    ) do
+
+      it "no deployment tag" do
+        expect(subject["tags"]).to be_nil
+      end
+
+      it "keeps @source.deployment" do
+        expect(subject["@source"]["deployment"]).to eq "deployment123"
+      end
+    end
+  end
 end

--- a/src/logsearch-config/test/logstash-filters/snippets/monitor_filter-spec.rb
+++ b/src/logsearch-config/test/logstash-filters/snippets/monitor_filter-spec.rb
@@ -31,4 +31,16 @@ describe "Rules for parsing haproxy messages" do
       end
     end
   end
+
+  context 'when [@source][deployment] is set' do
+    when_parsing_log(
+        "@source" => { "deployment" => "deployment123" }
+    ) do
+
+      it "drops event" do
+        expect(subject).to be_cancelled
+      end
+
+    end
+  end
 end


### PR DESCRIPTION
It can happen that [@source][deployment] field is parsed from a message. In this case there is no need to autodetect deployment value based on a job value. That's why we check if [@source][deployment] field is not set before doing deployment autodetection.