### PR TITLE
Add arbitrary kibana config options.

### DIFF
--- a/jobs/kibana/spec
+++ b/jobs/kibana/spec
@@ -37,6 +37,9 @@ properties:
   kibana.env:
     description: "a list of arbitrary key-value pairs to be passed on as process environment variables. eg: FOO: 123"
     default: []
+  kibana.config_options:
+    description: "Additional options to append to kibana's config.yml (YAML format)."
+    default: ~
   kibana.plugins:
     description: "a list of key-value pairs of plugins. e.b. Kibana-auth: /var/vcap/packagaes/kibana/kibana-auth"
     default: []

--- a/jobs/kibana/templates/config/kibana.conf.erb
+++ b/jobs/kibana/templates/config/kibana.conf.erb
@@ -79,3 +79,5 @@ elasticsearch.shardTimeout: <%= p('kibana.shard_timeout') %>
 
 # Set this to true to log all events, including system usage information and all requests.
 # logging.verbose: false
+
+<% if_p('kibana.config_options') do | v | %><%= v %><% end %>


### PR DESCRIPTION
Useful for configuring kibana plugins, for example.

Same as https://github.com/logsearch/logsearch-boshrelease/pull/251, similar to https://github.com/cloudfoundry-community/logsearch-for-cloudfoundry/pull/194.