### PR TITLE
Change nats_to_syslog parsing to use correct program name

### DIFF
--- a/src/logsearch-config/src/logstash-filters/default.conf.erb
+++ b/src/logsearch-config/src/logstash-filters/default.conf.erb
@@ -4,6 +4,6 @@ if [@type] in ["syslog", "relp"] {
   <%= File.read('src/logstash-filters/snippets/syslog_standard.conf').gsub(/^/, '  ') %>
 }
 
-if [syslog_program] == "nats-to-syslog" {
+if [syslog_program] == "nats_to_syslog" {
   <%= File.read('src/logstash-filters/snippets/bosh_nats.conf').gsub(/^/, '  ') %>
 }

--- a/src/logsearch-config/src/logstash-filters/snippets/bosh_nats.conf
+++ b/src/logsearch-config/src/logstash-filters/snippets/bosh_nats.conf
@@ -1,5 +1,5 @@
 # Parse BOSH NATS logs
-if [syslog_program] == "nats-to-syslog" {
+if [syslog_program] == "nats_to_syslog" {
   json {
     source => "@message"
     target => "NATS"

--- a/src/logsearch-config/target/logstash-filters-default.conf
+++ b/src/logsearch-config/target/logstash-filters-default.conf
@@ -115,9 +115,9 @@ if [@type] in ["syslog", "relp"] {
 
 }
 
-if [syslog_program] == "nats-to-syslog" {
+if [syslog_program] == "nats_to_syslog" {
     # Parse BOSH NATS logs
-  if [syslog_program] == "nats-to-syslog" {
+  if [syslog_program] == "nats_to_syslog" {
     json {
       source => "@message"
       target => "NATS"

--- a/src/logsearch-config/test/logstash-filters/defaults-spec.rb
+++ b/src/logsearch-config/test/logstash-filters/defaults-spec.rb
@@ -26,7 +26,7 @@ describe 'Logstash filters' do
   context "when parsing a logsearch cluster log message" do
     when_parsing_log(
       '@type' => "syslog",
-      '@message' => '<6>2016-04-12T13:04:56Z b5841bbc-ee95-48a9-8b42-0e60f52d1c5e nats-to-syslog[22919]: {"Data":"{\"deployment\":\"cf-a1-jarvice\",\"job\":\"ingestor\",\"index\":0,\"job_state\":\"running\",\"vitals\":{\"cpu\":{\"sys\":\"0.1\",\"user\":\"0.4\",\"wait\":\"0.2\"},\"disk\":{\"ephemeral\":{\"inode_percent\":\"0\",\"percent\":\"2\"},\"system\":{\"inode_percent\":\"31\",\"percent\":\"39\"}},\"load\":[\"0.00\",\"0.01\",\"0.05\"],\"mem\":{\"kb\":\"77300\",\"percent\":\"2\"},\"swap\":{\"kb\":\"0\",\"percent\":\"0\"}},\"node_id\":\"\"}","Reply":"","Subject":"hm.agent.heartbeat.1a03d017-68f3-4333-b05d-53ab95a6f3a4"}',
+      '@message' => '<6>2016-04-12T13:04:56Z b5841bbc-ee95-48a9-8b42-0e60f52d1c5e nats_to_syslog[22919]: {"Data":"{\"deployment\":\"cf-a1-jarvice\",\"job\":\"ingestor\",\"index\":0,\"job_state\":\"running\",\"vitals\":{\"cpu\":{\"sys\":\"0.1\",\"user\":\"0.4\",\"wait\":\"0.2\"},\"disk\":{\"ephemeral\":{\"inode_percent\":\"0\",\"percent\":\"2\"},\"system\":{\"inode_percent\":\"31\",\"percent\":\"39\"}},\"load\":[\"0.00\",\"0.01\",\"0.05\"],\"mem\":{\"kb\":\"77300\",\"percent\":\"2\"},\"swap\":{\"kb\":\"0\",\"percent\":\"0\"}},\"node_id\":\"\"}","Reply":"","Subject":"hm.agent.heartbeat.1a03d017-68f3-4333-b05d-53ab95a6f3a4"}',
     ) do
 
       it "applies the haproxy parsers successfully" do

--- a/src/logsearch-config/test/logstash-filters/snippets/bosh_nats-spec.rb
+++ b/src/logsearch-config/test/logstash-filters/snippets/bosh_nats-spec.rb
@@ -14,7 +14,7 @@ describe "BOSH NATS healthcheck log parsing rules" do
   describe "hm_agent_heartbeat logs" do
     when_parsing_log(
       '@type' => 'syslog',
-		  'syslog_program' => 'nats-to-syslog',
+		  'syslog_program' => 'nats_to_syslog',
       '@message' => '{"Data":"{\"job\":\"router-partition-7c53ed3ae2e7f5543b91\",\"index\":0,\"job_state\":\"running\",\"vitals\":{\"cpu\":{\"sys\":\"0.0\",\"user\":\"0.1\",\"wait\":\"0.1\"},\"disk\":{\"ephemeral\":{\"inode_percent\":\"2.0\",\"percent\":\"5.0\"},\"persistent\":{\"inode_percent\":\"44.0\",\"percent\":\"54.0\"}, \"system\":{\"inode_percent\":\"37.0\",\"percent\":\"46.0\"}},\"load\":[\"0.00\",\"0.02\",\"0.05\"],\"mem\":{\"kb\":\"81812.0\",\"percent\":\"8.0\"},\"swap\":{\"kb\":\"0.0\",\"percent\":\"0.0\"}},\"node_id\":\"\"}","Reply":"","Subject":"hm.agent.heartbeat.192dc853-4f1a-4198-8844-d0ab8d7c2c8e"}'
     ) do
 
@@ -118,15 +118,30 @@ describe "BOSH NATS healthcheck log parsing rules" do
     end
   end
 
-  describe "hm_alerts" do
+  describe "wrong program name (dash instead of underscore)" do
+    # tests fix for https://github.com/cloudfoundry-community/logsearch-boshrelease/issues/6
     when_parsing_log(
       '@type' => 'syslog',
-      'syslog_program' => 'nats-to-syslog',
+      'syslog_program' => 'nats-to-syslog', # dash instead of underscore
       "@message" => '{"Data":"{\"id\":\"a053e70a-3689-48f4-79a9-0341a6e2f071\",\"severity\":4,\"title\":\"SSH Login\",\"summary\":\"Accepted publickey for vcap from 10.0.0.6 port 60528 ssh2: RSA df:e1:f7:e0:23:59:86:da:ef:a6:7f:5d:ac:68:49:83\",\"created_at\":1457022703}","Reply":"","Subject":"hm.agent.alert.bb2e7409-8fec-4715-b2d7-bad5a08efe88"}'
     ) do
 
+      it "no NATS tag (= no nats parsing applied)" do
+          expect(subject["tags"]).to be_nil
+      end
+
+    end
+  end # describe hm_alerts
+
+  describe "hm_alerts" do
+    when_parsing_log(
+        '@type' => 'syslog',
+        'syslog_program' => 'nats_to_syslog',
+        "@message" => '{"Data":"{\"id\":\"a053e70a-3689-48f4-79a9-0341a6e2f071\",\"severity\":4,\"title\":\"SSH Login\",\"summary\":\"Accepted publickey for vcap from 10.0.0.6 port 60528 ssh2: RSA df:e1:f7:e0:23:59:86:da:ef:a6:7f:5d:ac:68:49:83\",\"created_at\":1457022703}","Reply":"","Subject":"hm.agent.alert.bb2e7409-8fec-4715-b2d7-bad5a08efe88"}'
+    ) do
+
       it "adds bosh nats tag" do
-          expect(subject["tags"]).to include "NATS"
+        expect(subject["tags"]).to include "NATS"
       end
 
       it "adds the HM alert" do


### PR DESCRIPTION
Fix for https://github.com/cloudfoundry-community/logsearch-boshrelease/issues/6.
Recently job nats-to-syslog was renamed to nats_to_syslog (underscore is now used instead of dash). But parsing was not updated accordingly and old name nats-to-syslog was used.
The commit fixes it by using new name nats_to_syslog.