### PR TITLE
Support custom haproxy configuration in kibana frontend

### DIFF
--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -63,6 +63,12 @@ properties:
   haproxy.kibana.auth.password:
     description: "Basic auth password for kibana. Optional"
     default: ""
+  haproxy.kibana.frontend.custom_config:
+    description: "Custom haproxy configuration. Optional."
+    example:
+    - http-response set-header X-Content-Type-Options nosniff
+    - http-response set-header X-XSS-Protection 1;\ mode=block
+    default: []
 
   haproxy.elastic.inbound_port:
     description: "The public port for Elasticsearch interface. IMPORTANT: Do not set this value unless you understand what are you doing! External access to Elasticsearch allows to do everything with it, including index deletion. Once enabled this feature, it is strictly recommended to set the password below."

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -50,6 +50,10 @@ frontend kibana-in
     http-request auth realm "Logs UI" if !logged_in
     <% end %>
 
+    <% p("haproxy.kibana.frontend.custom_config").each do |entry| %>
+      <%= entry %>
+    <% end %>
+
     default_backend kibana
 
 backend kibana


### PR DESCRIPTION
This PR allows specifying custom HAProxy configuration for the kibana frontend in the manifest.

If you think it would be useful, I could expand this PR to allow for config injection in each of the frontends/backends. WDYT?

cc: https://github.com/18F/cg-product/issues/473