### PR TITLE
Add possibility to test Logstash Bosh templates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ jdk:
 
 before_install:
   - gem update --system
-  - gem install rake
   - gem --version
 
 install:

--- a/src/logsearch-config/Gemfile
+++ b/src/logsearch-config/Gemfile
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+source "https://rubygems.org"
+
+group :test do
+  gem 'bosh-template'
+  gem 'rake'
+end

--- a/src/logsearch-config/Gemfile.lock
+++ b/src/logsearch-config/Gemfile.lock
@@ -1,0 +1,17 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    bosh-template (1.3262.24.0)
+      semi_semantic (~> 1.2.0)
+    rake (11.3.0)
+    semi_semantic (1.2.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  bosh-template
+  rake
+
+BUNDLED WITH
+   1.13.6

--- a/src/logsearch-config/Rakefile
+++ b/src/logsearch-config/Rakefile
@@ -1,4 +1,6 @@
 require 'erb'
+require 'yaml'
+require 'json'
 
 task :clean do
   mkdir_p "target"
@@ -15,10 +17,16 @@ task :build => :clean do
   puts `find target`
 end
 
-desc "Runs unit tests against filters & dashboards"
-task :test, [:rspec_files] => :build do |t, args|
-  args.with_defaults(:rspec_files => "$(find test -name '*spec.rb')")
-  puts "===> Testing ..."
+desc "Runs all tests"
+task test: [
+  :test_filters,
+  :test_templates
+]
+
+desc "Run unit tests against logstash filters"
+task :test_filters, [:rspec_files] => :build do |t, args|
+  args.with_defaults(:rspec_files => "$(find test/logstash-filters -name '*spec.rb')")
+  puts "===> Testing logstash filters ..."
   sh %Q[ LANGUAGE="C.UTF-8" LC_ALL="C.UTF-8" LANG="C.UTF-8" vendor/logstash/bin/rspec #{args[:rspec_files]} --colour --format progress --format html --out target/parsing_rules.html]
 end
 
@@ -29,4 +37,41 @@ def compile_erb(source_file, dest_file)
   else
     cp source_file, dest_file
   end
+end
+
+# -------- Templates tests ------------
+desc "Run unit tests against logstash templates"
+task :test_templates, [:rspec_files] => :compile_templates do |t, args|
+  args.with_defaults(:rspec_files => "$(find test/logstash-templates -name '*spec.rb')")
+  puts "===> Testing logstash templates ..."
+  sh %Q[ LANGUAGE="C.UTF-8" LC_ALL="C.UTF-8" LANG="C.UTF-8" vendor/logstash/bin/rspec #{args[:rspec_files]} --colour --format progress --format html --out target/templates.html]
+end
+
+task :clean_templates do
+  mkdir_p 'test/logstash-templates/target'
+  rm_rf 'test/logstash-templates/target/*'
+end
+
+desc "Compile bosh templates for tests"
+task :compile_templates => :clean_templates do
+  puts "===> Compiling Bosh templates for tests ..."
+
+  FileList.new("test/logstash-templates/*/compile.yml").each do |compile_file|
+    template = YAML.load_file(compile_file)['template'];
+    
+    template['testcase'].each do |template_testcase|
+      compile_bosh_template '../../' + template['path'], 'test/logstash-templates/' + template_testcase['config'], 'test/logstash-templates/' + template_testcase['destination']
+    end
+  end
+
+  puts "===> Compiled Templates:"
+  puts `find test/logstash-templates/target`
+end
+
+
+def compile_bosh_template(template_file, config_file, dest_file)
+
+  config = YAML.load(File.read(config_file)).to_json
+  `bosh-template #{template_file} --context '#{config}' > #{dest_file}`
+
 end

--- a/src/logsearch-config/bin/install-dependencies
+++ b/src/logsearch-config/bin/install-dependencies
@@ -9,6 +9,9 @@ fi
 
 LOGSTASH_VERSION=2.3.1
 
+echo "Installing gems specified in Gemfile..."
+cd $SCRIPT_DIR/../ && bundle install
+
 rm -f vendor/logstash
 if [ -e /usr/local/logstash-$LOGSTASH_VERSION ] ; then
   echo "Detected that running in Logsearch Workspace.  Linking to logstash at /usr/local/logstash-$LOGSTASH_VERSION"

--- a/src/logsearch-config/bin/test
+++ b/src/logsearch-config/bin/test
@@ -5,4 +5,10 @@ BASE_DIR=$(cd $SCRIPT_DIR/.. ; pwd)
 
 cd $BASE_DIR
 
-rake test["$1"]
+if [ $# -eq 0 ]
+  then rake test
+elif [ $# -eq 1 ]
+  then rake test $1
+elif [ $# -eq 2 ]
+  then rake test $1["$2"]
+fi

--- a/src/logsearch-config/test/logstash-templates/input_and_output/compile.yml
+++ b/src/logsearch-config/test/logstash-templates/input_and_output/compile.yml
@@ -1,0 +1,10 @@
+template: 
+  path: "jobs/parser/templates/config/input_and_output.conf.erb"
+  testcase:
+    - name: "default"
+      config: "input_and_output/test_default-config.yml"
+      destination: "target/input_and_output-default.conf"
+
+    - name: "enabled debug"
+      config: "input_and_output/test_enabled_debug-config.yml"
+      destination: "target/input_and_output-enabled_debug.conf"

--- a/src/logsearch-config/test/logstash-templates/input_and_output/spec.rb
+++ b/src/logsearch-config/test/logstash-templates/input_and_output/spec.rb
@@ -1,0 +1,22 @@
+require 'logstash/devutils/rspec/spec_helper'
+require 'test/templates_test_helpers'
+
+def verify_input_and_output(actual, expected)
+  pipelineActual = LogStash::Pipeline.new(File.read(File.join('test/logstash-templates/target', actual)))
+  pipelineExpected = LogStash::Pipeline.new(File.read(File.join('test/logstash-templates/input_and_output', expected)))
+
+  verify_collection("input", pipelineExpected.inputs, pipelineActual.inputs, "config")
+  verify_collection("output", pipelineExpected.outputs, pipelineActual.outputs, "config")
+end
+
+describe 'Parser input_and_output.conf' do
+
+  context "default" do
+    verify_input_and_output('input_and_output-default.conf', 'test_default-expected.conf')
+  end
+
+  context "enabled debug" do
+    verify_input_and_output('input_and_output-enabled_debug.conf', 'test_enabled_debug-expected.conf')
+  end
+
+end

--- a/src/logsearch-config/test/logstash-templates/input_and_output/test_default-config.yml
+++ b/src/logsearch-config/test/logstash-templates/input_and_output/test_default-config.yml
@@ -1,0 +1,17 @@
+---
+properties:
+  logstash_parser:
+    debug: false
+    inputs: [ { plugin: "redis", options : {} } ]
+    elasticsearch_document_id: ~
+    elasticsearch_index: "logs-%{[@metadata][index]}-%{+YYYY.MM.dd}"
+    elasticsearch_index_type: "%{@type}"
+  logstash:
+    output:
+      elasticsearch:
+        data_hosts: [127.0.0.1]
+        flush_size: 500
+  redis:
+    host: 127.0.0.1
+    port: 6379
+    key: logstash

--- a/src/logsearch-config/test/logstash-templates/input_and_output/test_default-expected.conf
+++ b/src/logsearch-config/test/logstash-templates/input_and_output/test_default-expected.conf
@@ -1,0 +1,20 @@
+input {
+    redis {     
+        host => "127.0.0.1"     
+        port => 6379    
+        type => "redis-input"     
+        data_type => "list"     
+        key => "logstash"
+        threads => 8 
+    }
+}
+
+output {
+    elasticsearch {
+        hosts => ["127.0.0.1:9200"]
+        flush_size => 500
+        index => "logs-%{[@metadata][index]}-%{+YYYY.MM.dd}"
+        document_type => "%{@type}"
+        manage_template => false
+    }   
+}

--- a/src/logsearch-config/test/logstash-templates/input_and_output/test_enabled_debug-config.yml
+++ b/src/logsearch-config/test/logstash-templates/input_and_output/test_enabled_debug-config.yml
@@ -1,0 +1,17 @@
+---
+properties:
+  logstash_parser:
+    debug: true
+    inputs: [ { plugin: "redis", options : {} } ]
+    elasticsearch_document_id: ~
+    elasticsearch_index: "logs-%{[@metadata][index]}-%{+YYYY.MM.dd}"
+    elasticsearch_index_type: "%{@type}"
+  logstash:
+    output:
+      elasticsearch:
+        data_hosts: [127.0.0.1]
+        flush_size: 500
+  redis:
+    host: 127.0.0.1
+    port: 6379
+    key: logstash

--- a/src/logsearch-config/test/logstash-templates/input_and_output/test_enabled_debug-expected.conf
+++ b/src/logsearch-config/test/logstash-templates/input_and_output/test_enabled_debug-expected.conf
@@ -1,0 +1,25 @@
+input {
+    redis {     
+        host => "127.0.0.1"     
+        port => 6379    
+        type => "redis-input"     
+        data_type => "list"     
+        key => "logstash"
+        threads => 8 
+    }
+}
+
+output {
+    
+    stdout {
+        codec => "json"
+    }
+
+    elasticsearch {
+        hosts => ["127.0.0.1:9200"]
+        flush_size => 500
+        index => "logs-%{[@metadata][index]}-%{+YYYY.MM.dd}"
+        document_type => "%{@type}"
+        manage_template => false
+    }   
+}

--- a/src/logsearch-config/test/templates_test_helpers.rb
+++ b/src/logsearch-config/test/templates_test_helpers.rb
@@ -1,0 +1,10 @@
+def verify_collection(description, collectionExpected, collectionActual, methodName)
+  
+  it "#{description}" do
+    expect(collectionActual.size).to eql(collectionExpected.size)
+    collectionExpected.each_with_index do |item, index|
+      expect(collectionActual[index].send(methodName)).to eql(item.send(methodName))
+    end
+  end
+
+end


### PR DESCRIPTION
Add bosh-template and rake gems to install-dependencies. Add scripts for
templates testing. Add first template tests - for input_and_output.erb.conf Bosh template.

This PR is usefult for testing changes in templates e.g. those needed for issue https://github.com/cloudfoundry-community/logsearch-boshrelease/issues/8.