### PR TITLE
Re-enabled shard allocation after deploy.

### DIFF
--- a/jobs/elasticsearch/spec
+++ b/jobs/elasticsearch/spec
@@ -6,6 +6,7 @@ packages:
 - java8
 templates:
   bin/drain.erb: bin/drain
+  bin/post-deploy.erb: bin/post-deploy
   bin/elasticsearch_ctl: bin/elasticsearch_ctl
   bin/monit_debugger: bin/monit_debugger
   config/config.yml.erb: config/elasticsearch.yml
@@ -16,10 +17,6 @@ templates:
   logsearch/metric-collector/elasticsearch/collector: logsearch/metric-collector/elasticsearch/collector
   logsearch/logs.yml: logsearch/logs.yml
 properties:
-  elasticsearch.drain:
-    description: Whether to use the built-in drain features to improve deployment reliability
-    # disabled while we do additional testing
-    default: false
   elasticsearch.master_hosts:
     description: The list of elasticsearch master node IPs
   elasticsearch.cluster_name:

--- a/jobs/elasticsearch/templates/bin/post-deploy.erb
+++ b/jobs/elasticsearch/templates/bin/post-deploy.erb
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+
+curl -s \
+    -X PUT \
+    -d '{"transient":{"cluster.routing.allocation.enable":"all"}}' \
+    '<%= p('elasticsearch.master_hosts').first %>:9200/_cluster/settings' \
+    > /dev/null


### PR DESCRIPTION
I'm thinking this should run in `post-deploy` instead of `post-start` because several jobs might pull in the `elasticsearch` template, including `elasticsearch_master`, `elasticsearch_data`, and `cluster_monitor`. I think we want to reenable shard allocation at the cluster level once *all* elasticsearch components have deployed. WDYT @Infra-Red?

[Resolves #18]