### PR TITLE
Update stub templates; fix deploy documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,28 +22,60 @@ Most users will want to combine Logsearch Core with a Logsearch Addon to customi
 particular type of logs.  Its likely you want to be following an Addon installation guides - see below
 for a list of the common Addons:
 
-  * [Logsearch for CloudFoundry](https://github.com/logsearch/logsearch-for-cloudfoundry)
+  * [Logsearch for CloudFoundry](https://github.com/cloudfoundry-community/logsearch-for-cloudfoundry)
 
 If you are sure you want install just Logsearch Core, read on...
 
 ## Installing Logsearch Core
 
-0. Upload the latest logsearch release from [bosh.io](https://bosh.io)...
+0. Upload the latest logserach release
 
-        $ bosh upload release https://bosh.io/d/github.com/logsearch/logsearch-boshrelease
+   * Download the latest logsearch release
+   
+     NOTE: At the moment you can get working logsearch release by cloning Git repository and creating bosh release from it.
 
+      Example:
+   
+      ```sh
+      $ git pull https://github.com/cloudfoundry-community/logsearch-boshrelease.git
+      $ cd logsearch-boshrelease
+      $ bosh create release
+      ```
+   
+   * Upload bosh release
+   
+      Example:
+
+      ```sh
+      $ bosh upload release
+      ```
+   
 0. Customise your deployment stub:
 
    * Make a copy of `templates/stub.$INFRASTRUCTURE.example.yml` to `logsearch-stub.yml`
-   * Edit to match your IAAS settings
+   
+      Example: 
+      ```sh
+      $ cp logsearch-boshrelease/templates/stub.openstack.example.yml logsearch-stub.yml
+      ```
+     
+   * Edit `logsearch-stub.yml` to match your IAAS settings
 
-0. Generate a manifest
+0. Generate a manifest with `scripts/generate_deployment_manifest $INFRASTRUCTURE logsearch-stub.yml > logsearch.yml`
 
-        $ scripts/generate_deployment_manifest $INFRASTRUCTURE logsearch-stub.yml > logsearch.yml
+   Example: 
+   
+   ```sh
+   $ logsearch-boshrelease/scripts/generate_deployment_manifest openstack logsearch-stub.yml > logsearch.yml
+   ```
+   
+   Notice `logsearch.yml` generated.
 
 0. Deploy!
 
-    $ bosh -d logsearch.yml deploy
+   ```sh
+   $ bosh -d logsearch.yml deploy
+   ```
 
 ## Common customisations:
 
@@ -60,7 +92,7 @@ If you are sure you want install just Logsearch Core, read on...
 
 ### Release Channels
 
- * The latest stable, final release is available on [bosh.io](http://bosh.io/releases/github.com/logsearch/logsearch-boshrelease)
+ * The latest stable, final release will be soon available on [bosh.io](http://bosh.io/releases)
  * **develop** - The develop branch in this repo is deployed to our test environments.  It is occasionally broken - use with care!
 
 ## Known issues

--- a/templates/logsearch-jobs.yml
+++ b/templates/logsearch-jobs.yml
@@ -78,16 +78,7 @@ jobs:
       filters:
       - monitor: /var/vcap/packages/logsearch-config/logstash-filters-monitor.conf
     nats_to_syslog:
-      nats:
-        subject: ">"
-        user: nats
-        password: nats-password
-        port: 4222
-        machines: []
-      debug: true
-      syslog:
-        host: 127.0.0.1
-        port: 514
+      debug: true      
     logstash_ingestor:
       syslog:
         port: 514
@@ -198,14 +189,6 @@ jobs:
     logstash_ingestor:
       syslog:
         port: 514
-    nats_to_syslog:
-      nats:
-        user: nats
-        password: nats-password
-        machines: [10.0.16.5]
-      syslog:
-        host: 127.0.0.1
-        port: 514
     syslog_forwarder:
       config:
       - {service: nats_to_syslog, file: /var/vcap/sys/log/nats_to_syslog/nats_to_syslog.stdout.log}
@@ -313,3 +296,14 @@ properties:
   syslog_forwarder:
     host: (( grab jobs.cluster_monitor.networks.default.static_ips.[0] ))
     port: (( grab jobs.cluster_monitor.properties.logstash_ingestor.syslog.port ))
+  nats_to_syslog:
+    # NATS settings of the Bosh Director
+    nats:
+      subject: ">"
+      user: nats
+      password: nats-password
+      port: 4222
+      machines: [10.0.16.5]
+    syslog:
+        host: 127.0.0.1
+        port: 514

--- a/templates/stub.aws.example.yml
+++ b/templates/stub.aws.example.yml
@@ -17,13 +17,6 @@ jobs:
 
 - name: cluster_monitor
   instances: 1
-  properties:
-    nats_to_syslog:
-      nats:
-        user: nats
-        password: nats-password
-        port: 4222
-        machines: [10.0.0.6]
 
 - name: queue
   instances: 1
@@ -54,7 +47,17 @@ jobs:
   - (( merge ))
   - name: elastic
     static_ips:
-    - SOME-ELASTIC-IP
+    - MY-ELASTIC-IP  # Specify an elastic IP for the router. Resources, proxied by the router, will be available through this IP. They include: kibana, elasticsearch, cluster_monitor, ingestor and syslog_server.
+
+properties:
+  nats_to_syslog:
+    # Specify the NATS settings of the Bosh Director
+    nats:
+      user: MY-NATS-USER  # Specify NATS user
+      password: MY-NATS-PASSWORD  # Specify NATS password
+      port: 4222  # Default value
+      machines: [10.0.0.6]  # Specify your NATS IPs
+
 
 disk_pools:
 - name: elasticsearch_master
@@ -73,7 +76,7 @@ networks:
   - range: 10.0.1.0/24
     gateway: 10.0.1.1
     cloud_properties:
-      subnet: SUBNET-ID
+      subnet: MY-SUBNET-ID  # Specify your subnetwork ID
       security_groups: [bosh]
     dns:
     - 10.10.0.2
@@ -83,3 +86,7 @@ networks:
     - 10.0.1.10 - 10.0.1.40
 - name: elastic
   type: vip
+  cloud_properties:
+    security_groups:  # Specify your security groups used for 'elastic' network
+    - MY-GROUP1
+    - MY-GROUP2

--- a/templates/stub.gcp.example.yml
+++ b/templates/stub.gcp.example.yml
@@ -53,14 +53,6 @@ jobs:
 
 - name: cluster_monitor
   instances: 1
-  properties:
-    nats_to_syslog:
-      nats:
-        user: nats
-        password: nats-password
-        port: 4222
-        machines: [10.0.0.6]
-
 
 - name: queue
   instances: 1
@@ -80,13 +72,6 @@ jobs:
 
 - name: ingestor-bosh-nats
   instances: 1
-  properties:
-    nats_to_syslog:
-      nats:
-        user: nats
-        password: nats-password
-        port: 4222
-        machines: [10.0.0.6]
 
 - name: parser
   instances: 2
@@ -101,7 +86,16 @@ jobs:
   #- (( merge ))
   #- name: elastic
   #  static_ips:
-  #  - SOME-ELASTIC-IP
+  #  - MY-ELASTIC-IP # Specify an elastic IP for the router. Resources, proxied by the router, will be available through this IP. They include: kibana, elasticsearch, cluster_monitor, ingestor and syslog_server.
+
+properties:
+  nats_to_syslog:
+    # Specify the NATS settings of the Bosh Director
+    nats:
+      user: MY-NATS-USER  # Specify NATS user
+      password: MY-NATS-PASSWORD  # Specify NATS password
+      port: 4222  # Default value
+      machines: [10.0.0.6]  # Specify your NATS IPs
 
 disk_pools:
 - name: elasticsearch_master
@@ -130,3 +124,7 @@ networks:
     - 10.201.0.2 - 10.201.0.253
 - name: elastic
   type: vip
+  cloud_properties:
+    security_groups:  # Specify your security groups used for 'elastic' network
+    - MY-GROUP1
+    - MY-GROUP2

--- a/templates/stub.openstack.example.yml
+++ b/templates/stub.openstack.example.yml
@@ -38,13 +38,6 @@ jobs:
   - name: default
     static_ips: (( static_ips(2) ))
   resource_pool: cluster_monitor
-  properties:
-    nats_to_syslog:
-      nats:
-        user: nats
-        password: nats-password
-        port: 4222
-        machines: [10.0.0.6]
 
 - name: queue
   instances: 1
@@ -105,8 +98,17 @@ jobs:
     static_ips: (( static_ips(5) ))
   - name: elastic
     static_ips:
-    - SOME-ELASTIC-IP
+    - MY-ELASTIC-IP  # Specify an elastic IP for the router. Resources, proxied by the router, will be available through this IP. They include: kibana, elasticsearch, cluster_monitor, ingestor and syslog_server.
   resource_pool: haproxy
+
+properties:
+  nats_to_syslog:
+    # Specify the NATS settings of the Bosh Director
+    nats:
+      user: MY-NATS-USER  # Specify NATS user
+      password: MY-NATS-PASSWORD  # Specify NATS password
+      port: 4222  # Default value
+      machines: [10.0.0.6]  # Specify your NATS IPs
 
 networks:
 - name: default
@@ -115,7 +117,7 @@ networks:
   - range: 10.0.1.0/24
     gateway: 10.0.1.1
     cloud_properties:
-      net_id: NET-ID
+      net_id: MY-NET-ID  # Specify your network ID
       security_groups: [bosh]
     dns:
     - 8.8.8.8
@@ -126,3 +128,7 @@ networks:
 
 - name: elastic
   type: vip
+  cloud_properties:
+    security_groups:  # Specify your security groups used for 'elastic' network
+    - MY-GROUP1
+    - MY-GROUP2

--- a/templates/stub.vsphere.example.yml
+++ b/templates/stub.vsphere.example.yml
@@ -13,13 +13,6 @@ jobs:
 
 - name: cluster_monitor
   instances: 1
-  properties:
-    nats_to_syslog:
-      nats:
-        user: nats
-        password: nats-password
-        port: 4222
-        machines: [10.0.0.6]
 
 - name: queue
   instances: 1
@@ -43,6 +36,15 @@ jobs:
 # Deploy group 3
 - name: ls-router
   instances: 1
+
+properties:
+  nats_to_syslog:
+    # Specify the NATS settings of the Bosh Director
+    nats:
+      user: MY-NATS-USER  # Specify NATS user
+      password: MY-NATS-PASSWORD  # Specify NATS password
+      port: 4222  # Default value
+      machines: [10.0.0.6]  # Specify your NATS IPs
 
 networks:
 - name: default

--- a/templates/stub.warden.example.yml
+++ b/templates/stub.warden.example.yml
@@ -14,13 +14,6 @@ jobs:
 
 - name: ingestor-bosh-nats
   instances: 1
-  properties:
-    nats_to_syslog:
-      nats:
-        user: nats
-        password: nats-password
-        port: 4222
-        machines: [10.254.50.4]
 
 - name: queue
   instances: 1
@@ -36,10 +29,12 @@ jobs:
 
 - name: cluster_monitor
   instances: 1
-  properties:
-    nats_to_syslog:
-      nats:
-        user: nats
-        password: nats-password
-        port: 4222
-        machines: [10.254.50.4]
+
+properties:
+  nats_to_syslog:
+    # Specify the NATS settings of the Bosh Director
+    nats:
+      user: MY-NATS-USER  # Specify NATS user
+      password: MY-NATS-PASSWORD  # Specify NATS password
+      port: 4222  # Default value
+      machines: [10.0.0.6]  # Specify your NATS IPs


### PR DESCRIPTION
1. Move nats_to_syslog properties to global because 2 jobs use them: ingestor-bosh-nats and cluster_monitor.
2. Use MY_* values for those fields that should be set with custom values. Add useful comments.
3. Update deploy documentation to be up-to-date.