### PR TITLE
Fix deployment

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -55,3 +55,19 @@ nats_to_syslog/nats_to_syslog_linux_amd64.tar.gz:
   object_id: 5d5d32dc-946c-4a27-9786-df4689706cdb
   sha: d27c56da9cdf214ed39a471f0ca5c970abbd510d
   size: 2094679
+ruby2.3/bundler-1.11.2.gem:
+  object_id: ce2c212f-c2ff-440e-9f4b-c2c214a010f9
+  sha: 8eb956dec72da753d3d2a2126c78508b17af434e
+  size: 263168
+ruby2.3/rake-11.2.2.gem:
+  object_id: 757c960e-1536-4be2-b0d9-d4f587e4c6ab
+  sha: 879e7c02b1a0b37333a91f11621f798deb874b6e
+  size: 102400
+ruby2.3/rubygems-2.6.4.tgz:
+  object_id: 4f90feb0-d0cf-41d8-a191-9b63e6f08f27
+  sha: 8ef39e536af2ecd20b0e7a95765fa6a485087ac8
+  size: 478582
+ruby2.3/ruby-2.3.1.tar.gz:
+  object_id: 0ab54e2b-3919-4e52-b157-50c8a7704cad
+  sha: c39b4001f7acb4e334cb60a0f4df72d434bef711
+  size: 17797997

--- a/jobs/parser/spec
+++ b/jobs/parser/spec
@@ -70,10 +70,10 @@ properties:
     default: "%{@type}"
   logstash_parser.elasticsearch.routing:
     description: "The routing to be used when indexing a document."
-  logstash.elasticsearch.data_hosts:
+  logstash_parser.elasticsearch.data_hosts:
     description: The list of elasticsearch data node IPs
     default: [127.0.0.1]
-  logstash.elasticsearch.flush_size:
+  logstash_parser.elasticsearch.flush_size:
     description: Controls how many logs will be buffered and sent to Elasticsearch for bulk indexing
     default: 500  
   logstash_parser.timecop.reject_greater_than_hours:

--- a/packages/logsearch-config/packaging
+++ b/packages/logsearch-config/packaging
@@ -5,6 +5,13 @@ set -u # report the usage of uninitialized variables
 # $BOSH_COMPILE_TARGET - where this package & spec'd source files are available
 # $BOSH_INSTALL_TARGET - where you copy/install files to be included in package
 
+export PATH=/var/vcap/packages/ruby2.3/bin:$PATH
+
+logsearch-config/bin/build
+
 cp logsearch-config/target/* $BOSH_INSTALL_TARGET
 cp logsearch-config/mappings/* $BOSH_INSTALL_TARGET
-cp logsearch-config/src/logstash-filters/* $BOSH_INSTALL_TARGET
+cp logsearch-config/src/logstash-filters/if_it_looks_like_json.conf $BOSH_INSTALL_TARGET
+cp logsearch-config/src/logstash-filters/timecop.conf $BOSH_INSTALL_TARGET
+cp logsearch-config/src/logstash-filters/deployment.conf $BOSH_INSTALL_TARGET
+cp logsearch-config/src/logstash-filters/deployment_lookup.yml $BOSH_INSTALL_TARGET

--- a/packages/logsearch-config/spec
+++ b/packages/logsearch-config/spec
@@ -1,10 +1,8 @@
 ---
 name: logsearch-config
-dependencies: []
+
+dependencies:
+  - ruby2.3
+
 files:
-- logsearch-config/target/*.conf
-- logsearch-config/mappings/*.json
-- logsearch-config/src/logstash-filters/if_it_looks_like_json.conf
-- logsearch-config/src/logstash-filters/timecop.conf
-- logsearch-config/src/logstash-filters/deployment.conf
-- logsearch-config/src/logstash-filters/deployment_lookup.yml
+- logsearch-config/**/*

--- a/packages/ruby2.3/README.md
+++ b/packages/ruby2.3/README.md
@@ -1,0 +1,12 @@
+ruby-package
+============
+This repo is used for ruby packaging in BOSH deployments.
+
+The files can be downloaded from the following locations:
+
+| Filename | Download URL |
+| -------- | ------------ |
+| ruby-2.3.1.tar.gz | [ruby-lang.org](http://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.1.tar.gz) |
+| rubygems-2.6.4.tgz | [rubygems.org](http://production.cf.rubygems.org/rubygems/rubygems-2.6.4.tgz) |
+| bundler-1.11.2.gem | [rubygems.org](https://rubygems.org/downloads/bundler-1.11.2.gem) |
+| rake-11.2.2.gem | [rubygems.org](https://rubygems.org/downloads/rake-11.2.2.gem) |

--- a/packages/ruby2.3/packaging
+++ b/packages/ruby2.3/packaging
@@ -1,0 +1,34 @@
+# abort script on any command that exits with a non zero value
+set -e
+
+# We grab the latest versions that are in the directory
+RUBY_VERSION=`ls -r ruby2.3/ruby-* | sed 's/ruby2.3\/ruby-\(.*\)\.tar\.gz/\1/' | head -1`
+RUBYGEMS_VERSION=`ls -r ruby2.3/rubygems-* | sed 's/ruby2.3\/rubygems-\(.*\)\.tgz/\1/' | head -1`
+BUNDLER_VERSION=`ls -r ruby2.3/bundler-* | sed 's/ruby2.3\/bundler-\(.*\)\.gem/\1/' | head -1`
+RAKE_VERSION=`ls -r ruby2.3/rake-* | sed 's/ruby2.3\/rake-\(.*\)\.gem/\1/' | head -1`
+
+tar xzf ruby2.3/ruby-${RUBY_VERSION}.tar.gz
+(
+  set -e
+  cd ruby-${RUBY_VERSION}
+  LDFLAGS="-Wl,-rpath -Wl,${BOSH_INSTALL_TARGET}" ./configure --prefix=${BOSH_INSTALL_TARGET} --disable-install-doc --with-opt-dir=${BOSH_INSTALL_TARGET}
+  make
+  make install
+)
+
+tar zxvf ruby2.3/rubygems-${RUBYGEMS_VERSION}.tgz
+(
+  set -e
+  cd rubygems-${RUBYGEMS_VERSION}
+
+  ${BOSH_INSTALL_TARGET}/bin/ruby setup.rb
+
+  if [[ $? != 0 ]] ; then
+    echo "Cannot install rubygems"
+    exit 1
+  fi
+)
+
+${BOSH_INSTALL_TARGET}/bin/gem install ruby2.3/bundler-${BUNDLER_VERSION}.gem --local --no-ri --no-rdoc
+
+${BOSH_INSTALL_TARGET}/bin/gem install ruby2.3/rake-${RAKE_VERSION}.gem --local --no-ri --no-rdoc

--- a/packages/ruby2.3/spec
+++ b/packages/ruby2.3/spec
@@ -1,0 +1,8 @@
+---
+name: ruby2.3
+
+files:
+  - ruby2.3/ruby-2.3.1.tar.gz
+  - ruby2.3/rubygems-2.6.4.tgz
+  - ruby2.3/bundler-1.11.2.gem
+  - ruby2.3/rake-11.2.2.gem

--- a/src/logsearch-config/test/logstash-filters/snippets/syslog_standard-spec.rb
+++ b/src/logsearch-config/test/logstash-filters/snippets/syslog_standard-spec.rb
@@ -227,7 +227,7 @@ describe LogStash::Filters::Grok do
     end
 
     when_parsing_log(
-      '@message' => "<46>Dec 16 15:24:05 haproxy[9252]: 52.62.56.30:45940 [16/Dec/2015:15:24:02.638] syslog-in~ ingestors/node1 328/-1/3332 0 SC 8/8/8/0/3 0/0",
+      '@message' => "<46>Apr 16 15:24:05 haproxy[9252]: 52.62.56.30:45940 [16/Dec/2015:15:24:02.638] syslog-in~ ingestors/node1 328/-1/3332 0 SC 8/8/8/0/3 0/0",
       '@type' => 'syslog'
     ) do
 
@@ -236,7 +236,7 @@ describe LogStash::Filters::Grok do
       end
 
       it "extracts the timestamp" do
-        expect(subject['@timestamp']).to eq Time.parse("#{Time.now.year}-12-16T15:24:05Z")
+        expect(subject['@timestamp']).to eq Time.iso8601("#{Time.now.year}-04-16T15:24:05.000Z")
       end
 
       it "drops the syslog_timestamp field (since it has been captured in @timestamp)" do


### PR DESCRIPTION
This PR includes fixes for recent bugs affecting deployment

1) Fix property name logstash.elasticsearch* ->
logstash_parser.elasticsearch*

2) Do build logsearch configs during packaging

Recently the target folder was emptied. So we need to build logsearch configs to get compiled configs there when packaging.
Also add ruby package to be used for logsearch-config building.