### PR TITLE
Use logstash redis defaults.

### DIFF
--- a/jobs/ingestor_syslog/spec
+++ b/jobs/ingestor_syslog/spec
@@ -61,10 +61,8 @@ properties:
     default: logstash
   redis.congestion_interval:
     description: How often to check for queue length. Default is one second. Zero means to check on every message
-    default: 10
   redis.congestion_threshold:
     description: Max number of messages to allow in the queue.  Will stop (and drop) ingesting new messages when this is reached
-    default: 1000000
 
   archiver.enabled:
     default: false

--- a/jobs/ingestor_syslog/templates/config/logstash.conf.erb
+++ b/jobs/ingestor_syslog/templates/config/logstash.conf.erb
@@ -1,36 +1,36 @@
 input {
-	<% if p("logstash_ingestor.syslog.port") %>
-	tcp {
-		add_field => [ "type", "syslog" ]
-		host => "0.0.0.0"
-		port => "<%= p("logstash_ingestor.syslog.port") %>"
-	}
-	udp {
-		add_field => [ "type", "syslog" ]
-		host => "0.0.0.0"
-		port => "<%= p("logstash_ingestor.syslog.port") %>"
-	}
-	<% end %>
+  <% if p("logstash_ingestor.syslog.port") %>
+  tcp {
+    add_field => [ "type", "syslog" ]
+    host => "0.0.0.0"
+    port => "<%= p("logstash_ingestor.syslog.port") %>"
+  }
+  udp {
+    add_field => [ "type", "syslog" ]
+    host => "0.0.0.0"
+    port => "<%= p("logstash_ingestor.syslog.port") %>"
+  }
+  <% end %>
 
-	<% if_p("logstash_ingestor.syslog_tls.port") do | port | %>
-	tcp {
-		add_field => [ "type", "syslog" ]
-		host => "0.0.0.0"
-		port => "<%= port %>"
-		ssl_enable => true
-		ssl_cert => "/var/vcap/jobs/ingestor_syslog/config/syslog_tls.crt"
-		ssl_key => "/var/vcap/jobs/ingestor_syslog/config/syslog_tls.key"
-	}
-	<% end %>
+  <% if_p("logstash_ingestor.syslog_tls.port") do | port | %>
+  tcp {
+    add_field => [ "type", "syslog" ]
+    host => "0.0.0.0"
+    port => "<%= port %>"
+    ssl_enable => true
+    ssl_cert => "/var/vcap/jobs/ingestor_syslog/config/syslog_tls.crt"
+    ssl_key => "/var/vcap/jobs/ingestor_syslog/config/syslog_tls.key"
+  }
+  <% end %>
 
-	<% if_p("logstash_ingestor.relp.port") do | port | %>
-	relp {
-		add_field => { "_logstash_input" => "relp" }
-		host => "0.0.0.0"
-		port => "<%= port %>"
-	}
-	<% end %>
-	}
+  <% if_p("logstash_ingestor.relp.port") do | port | %>
+  relp {
+    add_field => { "_logstash_input" => "relp" }
+    host => "0.0.0.0"
+    port => "<%= port %>"
+  }
+  <% end %>
+}
 
 filter {
   # drop empty logs (eg: monit connection healthcheck)
@@ -40,62 +40,68 @@ filter {
 
   #When behind haproxy, this is always the IP of the haproxy, not the IP of the actual host sending the data.
   #Remove it to avoid confusion
-	mutate {
-		remove_field => [ "host" ]
-	}
-	<% if 'DEBUG' == p('logstash.metadata_level') %>
-	mutate {
-		add_field => { "[@ingestor][service]" => "syslog" }
-		add_field => { "[@ingestor][job]" => "<%= name %>/<%= index %>" }
-	}
-	ruby {
-		code => "event['@ingestor']['timestamp'] = Time.now.iso8601(3)"
-	}
-	<% end %>
+  mutate {
+    remove_field => [ "host" ]
+  }
+  <% if 'DEBUG' == p('logstash.metadata_level') %>
+  mutate {
+    add_field => { "[@ingestor][service]" => "syslog" }
+    add_field => { "[@ingestor][job]" => "<%= name %>/<%= index %>" }
+  }
+  ruby {
+    code => "event['@ingestor']['timestamp'] = Time.now.iso8601(3)"
+  }
+  <% end %>
 
-	#
-	# Injected custom filters below from logstash_inject.filters manifest property
-	#
-	<%= p('logstash_ingestor.filters') %>
+  #
+  # Injected custom filters below from logstash_inject.filters manifest property
+  #
+  <%= p('logstash_ingestor.filters') %>
 }
 
 output {
-	<% if p("logstash_ingestor.debug") %>
-        stdout {
-            codec => "json"
-        }
-	<% end %>
+  <% if p("logstash_ingestor.debug") %>
+    stdout {
+      codec => "json"
+    }
+  <% end %>
 
-	<% if_p("logstash_ingestor.outputs") do |ingestor_outputs| %>
-	  <% ingestor_outputs.each do | output | %>
-	    <%= output['plugin'] %> {
-              <% if 'redis' == output['plugin'] %>
-                <% output['options'] = {
-                  "host" => p('redis.host'),
-                  "port" => p('redis.port'),
-                  "data_type" => "list",
-                  "key" => p('redis.key'),
-                  "batch" => true,
-                  "batch_events" => 50,
-                  "congestion_interval" => p('redis.congestion_interval'),
-                  "congestion_threshold" => p('redis.congestion_threshold')
-                } %>
-              <% end %>
-	      <% output['options'].each do | k, v | %>
-	        <%= k %> => <%= v.inspect %>
-	      <% end %>
-	    }
-	  <% end %>
-	<% end %>
+  <% if_p("logstash_ingestor.outputs") do |ingestor_outputs| %>
+    <% ingestor_outputs.each do |output| %>
+      <%= output['plugin'] %> {
+        <%
+          if 'redis' == output['plugin']
+            output['options'] = {
+              "host" => p('redis.host'),
+              "port" => p('redis.port'),
+              "data_type" => "list",
+              "key" => p('redis.key'),
+              "batch" => true,
+              "batch_events" => 50,
+            }
+            if_p('redis.congestion_interval') do |interval|
+              output['options']['congestion_interval'] = interval
+            end
+            if_p('redis.congestion_threshold') do |threshold|
+              output['options']['congestion_threshold'] = threshold
+            end
+          end
+        %>
+        <% output['options'].each do | k, v | %>
+          <%= k %> => <%= v.inspect %>
+        <% end %>
+      }
+    <% end %>
+  <% end %>
 
-	<% if p('archiver.enabled') %>
-		redis {
-			host => "<%= p("redis.host") %>"
-			port => "<%= p("redis.port") %>"
-			data_type => "list"
-			key => "<%= p("redis.key") %>_archiver"
-			batch => true
-			batch_events => 50
-		}
-	<% end %>
+  <% if p('archiver.enabled') %>
+    redis {
+      host => "<%= p("redis.host") %>"
+      port => "<%= p("redis.port") %>"
+      data_type => "list"
+      key => "<%= p("redis.key") %>_archiver"
+      batch => true
+      batch_events => 50
+    }
+  <% end %>
 }

--- a/jobs/ingestor_syslog/templates/config/logstash.conf.erb
+++ b/jobs/ingestor_syslog/templates/config/logstash.conf.erb
@@ -71,7 +71,7 @@ output {
       <%= output['plugin'] %> {
         <%
           if 'redis' == output['plugin']
-            output['options'] = {
+            options = {
               "host" => p('redis.host'),
               "port" => p('redis.port'),
               "data_type" => "list",
@@ -80,11 +80,12 @@ output {
               "batch_events" => 50,
             }
             if_p('redis.congestion_interval') do |interval|
-              output['options']['congestion_interval'] = interval
+              options['congestion_interval'] = interval
             end
             if_p('redis.congestion_threshold') do |threshold|
-              output['options']['congestion_threshold'] = threshold
+              options['congestion_threshold'] = threshold
             end
+            output['options'] = output.merge(output['options'])
           end
         %>
         <% output['options'].each do | k, v | %>

--- a/jobs/parser/templates/config/input_and_output.conf.erb
+++ b/jobs/parser/templates/config/input_and_output.conf.erb
@@ -3,14 +3,16 @@ input {
 <% p('logstash_parser.inputs').each do | input | %>
     <%= input['plugin'] %> {
       <% if 'redis' == input['plugin'] %>
-        <% input['options'] = {
-           "host" => p('redis.host'),
-           "port" => p('redis.port'),
-           "type" => "redis-input",
-           "data_type" => "list",
-           "key" => p('redis.key'),
-           "threads" => 8
-         } %>
+        <%
+          options = {
+            "host" => p('redis.host'),
+            "port" => p('redis.port'),
+            "type" => "redis-input",
+            "data_type" => "list",
+            "key" => p('redis.key'),
+          }
+          input['options'] = options.merge(input['options'])
+        %>
       <% end %>
       <% input['options'].each do | k, v | %>
         <%= k %> => <%= v.inspect %>
@@ -31,22 +33,24 @@ output {
     <% p('logstash_parser.outputs').each do | output | %>
         <%= output['plugin'] %> {
         <% if 'elasticsearch' == output['plugin'] %>
-            <% output['options'] = {
+            <%
+              options = {
                 "hosts" => [ p('logstash_parser.elasticsearch.data_hosts').map { |ip| "#{ip}:9200" }.join(',') ],
-                "flush_size" => p('logstash_parser.elasticsearch.flush_size'),               
+                "flush_size" => p('logstash_parser.elasticsearch.flush_size'),
                 "index" => p('logstash_parser.elasticsearch.index'),
                 "document_type" => p('logstash_parser.elasticsearch.index_type'),
-                "manage_template" => false              
-            } 
-            if p('logstash_parser.elasticsearch.idle_flush_time', nil)
-                output['options']['idle_flush_time'] = p('logstash_parser.elasticsearch.idle_flush_time')
-            end
-            if p('logstash_parser.elasticsearch.document_id', nil)
-                output['options']['document_id'] = p('logstash_parser.elasticsearch.document_id')
-            end
-            if p('logstash_parser.elasticsearch.routing', nil)
-                output['options']['routing'] = p('logstash_parser.elasticsearch.routing')
-            end
+                "manage_template" => false
+              }
+              if p('logstash_parser.elasticsearch.idle_flush_time', nil)
+                options['idle_flush_time'] = p('logstash_parser.elasticsearch.idle_flush_time')
+              end
+              if p('logstash_parser.elasticsearch.document_id', nil)
+                options['document_id'] = p('logstash_parser.elasticsearch.document_id')
+              end
+              if p('logstash_parser.elasticsearch.routing', nil)
+                options['routing'] = p('logstash_parser.elasticsearch.routing')
+              end
+              output['options'] = options.merge(output['options'])
             %>
         <% end %>
         <% output['options'].each do | k, v | %>

--- a/src/logsearch-config/test/logstash-templates/input_and_output/compile.yml
+++ b/src/logsearch-config/test/logstash-templates/input_and_output/compile.yml
@@ -1,4 +1,4 @@
-template: 
+template:
   path: "jobs/parser/templates/config/input_and_output.conf.erb"
   testcase:
     - name: "default"
@@ -16,7 +16,7 @@ template:
     - name: "inputs - no redis"
       config: "input_and_output/test_inputs_no_redis-config.yml"
       destination: "target/input_and_output-test_inputs_no_redis.conf"
-    
+
     - name: "outputs"
       config: "input_and_output/test_outputs-config.yml"
       destination: "target/input_and_output-test_outputs.conf"

--- a/src/logsearch-config/test/logstash-templates/input_and_output/test_default-config.yml
+++ b/src/logsearch-config/test/logstash-templates/input_and_output/test_default-config.yml
@@ -4,7 +4,7 @@
 properties:
   logstash_parser:
     debug: false
-    inputs: [ { plugin: "redis", options : {} } ]
+    inputs: [ { plugin: "redis", options : { threads: 8 } } ]
     outputs: [ { plugin: "elasticsearch", options: {} } ]
     elasticsearch:
       document_id: ~

--- a/src/logsearch-config/test/logstash-templates/input_and_output/test_enabled_debug-config.yml
+++ b/src/logsearch-config/test/logstash-templates/input_and_output/test_enabled_debug-config.yml
@@ -4,7 +4,7 @@
 properties:
   logstash_parser:
     debug: true
-    inputs: [ { plugin: "redis", options : {} } ]
+    inputs: [ { plugin: "redis", options : { threads: 8 } } ]
     outputs: [ { plugin: "elasticsearch", options: {} } ]
     elasticsearch:
       document_id: ~

--- a/src/logsearch-config/test/logstash-templates/input_and_output/test_inputs-config.yml
+++ b/src/logsearch-config/test/logstash-templates/input_and_output/test_inputs-config.yml
@@ -4,7 +4,7 @@
 properties:
   logstash_parser:
     debug: false
-    inputs: [ { plugin: "redis", options : {} }, { plugin: "file", options: { path: "my/path/to/file" } }, { plugin: "syslog", options: { host: "127.0.0.1", port: 123} } ]
+    inputs: [ { plugin: "redis", options : { threads: 8 } }, { plugin: "file", options: { path: "my/path/to/file" } }, { plugin: "syslog", options: { host: "127.0.0.1", port: 123} } ]
     outputs: [ { plugin: "elasticsearch", options: {} } ]
     elasticsearch:
       document_id: ~

--- a/src/logsearch-config/test/logstash-templates/input_and_output/test_outputs-config.yml
+++ b/src/logsearch-config/test/logstash-templates/input_and_output/test_outputs-config.yml
@@ -4,7 +4,7 @@
 properties:
   logstash_parser:
     debug: true
-    inputs: [ { plugin: "redis", options : {} } ]
+    inputs: [ { plugin: "redis", options : { threads: 8 } } ]
     outputs: [ { plugin: "elasticsearch", options: {} }, { plugin: "mongodb", options: { uri: "192.168.1.1", database: "logsearch", collection: "logs" } }, { plugin: "syslog", options: { host: "127.0.0.1", port: 123} } ]
     elasticsearch:
       document_id: ~

--- a/src/logsearch-config/test/logstash-templates/input_and_output/test_outputs_elasticsearch_all_properties-config.yml
+++ b/src/logsearch-config/test/logstash-templates/input_and_output/test_outputs_elasticsearch_all_properties-config.yml
@@ -4,7 +4,7 @@
 properties:
   logstash_parser:
     debug: false
-    inputs: [ { plugin: "redis", options : {} } ]
+    inputs: [ { plugin: "redis", options : { threads: 8 } } ]
     outputs: [ { plugin: "elasticsearch", options: {} } ]
     elasticsearch:
       document_id: "abc"

--- a/src/logsearch-config/test/logstash-templates/input_and_output/test_outputs_elasticsearch_required_properties-config.yml
+++ b/src/logsearch-config/test/logstash-templates/input_and_output/test_outputs_elasticsearch_required_properties-config.yml
@@ -4,7 +4,7 @@
 properties:
   logstash_parser:
     debug: false
-    inputs: [ { plugin: "redis", options : {} } ]
+    inputs: [ { plugin: "redis", options : { threads: 8 } } ]
     outputs: [ { plugin: "elasticsearch", options: {} } ]
     elasticsearch:
       index: "logs-%{[@metadata][index]}-%{+YYYY.MM.dd}"

--- a/src/logsearch-config/test/logstash-templates/input_and_output/test_outputs_no_elasticsearch-config.yml
+++ b/src/logsearch-config/test/logstash-templates/input_and_output/test_outputs_no_elasticsearch-config.yml
@@ -4,7 +4,7 @@
 properties:
   logstash_parser:
     debug: false
-    inputs: [ { plugin: "redis", options : {} } ]
+    inputs: [ { plugin: "redis", options : { threads: 8 } } ]
     outputs: [ { plugin: "mongodb", options: { uri: "192.168.1.1", database: "logsearch", collection: "logs" } }, { plugin: "syslog", options: { host: "127.0.0.1", port: 123} } ]
     elasticsearch:
       document_id: ~


### PR DESCRIPTION
[Resolves #24]

Most of the diffs here are changing tabs to spaces. The only meaningful change is dropping the default redis congestion properties, then only adding them to the redis options if defined.