### PR TITLE
Make prefix of index pattern in ES settings/mappings configurable

### DIFF
--- a/jobs/elasticsearch_config/spec
+++ b/jobs/elasticsearch_config/spec
@@ -1,18 +1,29 @@
 ---
 name: "elasticsearch_config"
+
 packages:
   - "elasticsearch"
   - "java8"
-  - "logsearch-config"
+
 templates:
-  bin/run.erb: "bin/run"
-  bin/job.process: "bin/job.process"
+  bin/run.erb:                          bin/run
+  bin/job.process:                      bin/job.process
+  index-templates/shards-and-replicas.json.erb:  index-templates/shards-and-replicas.json
+  index-templates/index-settings.json.erb:  index-templates/index-settings.json
+  index-templates/index-mappings.json.erb:  index-templates/index-mappings.json
+
 properties:
   elasticsearch_config.elasticsearch.host:
     description: "The elasticsearch master node hostname"
   elasticsearch_config.elasticsearch.port:
     description: "the elasticsearch master node port"
     default: 9200
+  elasticsearch_config.index_prefix:
+    description: |
+      Name prefix of your log indices that can uniquely distinguish them among other ES indices if apply pattern '*' to it, e.g. 'logs-*'. 
+      It is used in the index templates predefined in the job to specify index pattern.
+      Make sure the prefix matches `logstash_parser.elasticsearch.index` property set for your parser.
+    default: "logstash-"
   elasticsearch_config.templates:
     description: "An array with key-value hashes; keys being template name, value being template content"
     default: []
@@ -20,5 +31,4 @@ properties:
     description: "An array with key-value hashes; keys being doc path, value being doc source"
     default: []
   elasticsearch_config.license:
-    description: The ElasticSearch License string
-
+    description: "The ElasticSearch License string"

--- a/jobs/elasticsearch_config/templates/index-templates/index-mappings.json.erb
+++ b/jobs/elasticsearch_config/templates/index-templates/index-mappings.json.erb
@@ -1,25 +1,12 @@
 {
-  "template": "logstash-*",
-  "order": 50,
-  "settings": {
+  "template": "<%= p('elasticsearch_config.index_prefix') %>*",
+  "order": 102,
+  "settings": { 
     "index": {
-      "codec": "best_compression",
-      "search": {
-        "slowlog": {
-          "threshold": {
-            "query": {
-              "warn": "30s",
-              "info": "15s",
-              "debug": "10s",
-              "trace": "5s"
-            }
-          }
-        }
-      },
       "query": {
         "default_field": "@raw"
       }
-    }
+    }    
   },
   "mappings": {
     "_default_": {

--- a/jobs/elasticsearch_config/templates/index-templates/index-settings.json.erb
+++ b/jobs/elasticsearch_config/templates/index-templates/index-settings.json.erb
@@ -1,0 +1,21 @@
+{
+  "template": "<%= p('elasticsearch_config.index_prefix') %>*",
+  "order": 101,
+  "settings": { 
+    "index": {
+      "codec": "best_compression",
+      "search": {
+        "slowlog": {
+          "threshold": {
+            "query": {
+              "warn": "30s",
+              "info": "15s",
+              "debug": "10s",
+              "trace": "5s"
+            }
+          }
+        }
+      }      
+    }    
+  }
+}

--- a/jobs/elasticsearch_config/templates/index-templates/shards-and-replicas.json.erb
+++ b/jobs/elasticsearch_config/templates/index-templates/shards-and-replicas.json.erb
@@ -1,0 +1,8 @@
+{
+  "template": "<%= p('elasticsearch_config.index_prefix') %>*",
+  "order": 100,
+  "settings": { 
+    "number_of_shards": 5,
+    "number_of_replicas" : 1    
+  }
+}

--- a/packages/logsearch-config/packaging
+++ b/packages/logsearch-config/packaging
@@ -10,7 +10,6 @@ export PATH=/var/vcap/packages/ruby2.3/bin:$PATH
 logsearch-config/bin/build
 
 cp logsearch-config/target/* $BOSH_INSTALL_TARGET
-cp logsearch-config/mappings/* $BOSH_INSTALL_TARGET
 cp logsearch-config/src/logstash-filters/if_it_looks_like_json.conf $BOSH_INSTALL_TARGET
 cp logsearch-config/src/logstash-filters/timecop.conf $BOSH_INSTALL_TARGET
 cp logsearch-config/src/logstash-filters/deployment.conf $BOSH_INSTALL_TARGET

--- a/src/logsearch-config/Rakefile
+++ b/src/logsearch-config/Rakefile
@@ -7,7 +7,7 @@ task :clean do
   FileUtils.rm_rf(Dir.glob('target/*'))
 end
 
-desc "Builds filters & dashboards"
+desc "Builds logstash filters"
 task :build => :clean do
   puts "===> Building ..."
   compile_erb 'src/logstash-filters/default.conf.erb', 'target/logstash-filters-default.conf'

--- a/templates/logsearch-jobs.yml
+++ b/templates/logsearch-jobs.yml
@@ -71,10 +71,13 @@ jobs:
       elasticsearch:
         host: 127.0.0.1
         port: 9200
+      index_prefix: "logstash-"
       templates:
-      - shards-and-replicas: "{ \"template\" : \"*\", \"order\" : 99, \"settings\" : { \"number_of_shards\" : 1, \"number_of_replicas\" : 0 } }"
-      - index_template: /var/vcap/packages/logsearch-config/default-mappings.json
+        - shards-and-replicas: "{ \"template\" : \"logstash-*\", \"order\" : 100, \"settings\" : { \"number_of_shards\" : 1, \"number_of_replicas\" : 0 } }"
+        - index-settings: /var/vcap/jobs/elasticsearch_config/index-templates/index-settings.json
+        - index-mappings: /var/vcap/jobs/elasticsearch_config/index-templates/index-mappings.json
     logstash_parser:
+      logstash_parser.elasticsearch.index: "logstash-%{+YYYY.MM.dd}"
       filters:
       - monitor: /var/vcap/packages/logsearch-config/logstash-filters-monitor.conf
     nats_to_syslog:
@@ -214,7 +217,7 @@ jobs:
       - {service: parser, file: /var/vcap/sys/log/parser/parser.stderr.log}
 
 ####################################################
-#3nd deploy group - ls-router (haproxy), and errands
+#3rd deploy group - ls-router (haproxy), and errands
 ####################################################
 
 - name: ls-router
@@ -290,8 +293,9 @@ properties:
     elasticsearch:
       host: (( grab jobs.elasticsearch_master.networks.default.static_ips.[0] ))
     templates:
-      - index_template: /var/vcap/packages/logsearch-config/default-mappings.json
-      - shards-and-replicas: "{ \"template\" : \"*\", \"order\" : 99, \"settings\" : { \"number_of_shards\" : 5, \"number_of_replicas\" : 1 } }"
+      - shards-and-replicas: /var/vcap/jobs/elasticsearch_config/index-templates/shards-and-replicas.json
+      - index-settings: /var/vcap/jobs/elasticsearch_config/index-templates/index-settings.json
+      - index-mappings: /var/vcap/jobs/elasticsearch_config/index-templates/index-mappings.json
   syslog_forwarder:
     host: (( grab jobs.cluster_monitor.networks.default.static_ips.[0] ))
     port: (( grab jobs.cluster_monitor.properties.logstash_ingestor.syslog.port ))


### PR DESCRIPTION
Move index templates from package `logsearch-config` to job `elasticsearch_config` in order to use deploy properties. Split predefined index template into three: 1st) configures shards and replicas, 2nd) configures useful index settings 3rd) configures index mappings. Make index templates use property `elasticsearch_config.index_prefix`.