### PR TITLE
Expose max file descriptors.

### DIFF
--- a/jobs/elasticsearch/spec
+++ b/jobs/elasticsearch/spec
@@ -37,6 +37,9 @@ properties:
   elasticsearch.exec.options:
     description: An array of additional options to pass when starting elasticsearch
     default: []
+  elasticsearch.limits.fd:
+    description: Maximum file descriptors
+    default: 65536
   elasticsearch.discovery.minimum_master_nodes:
     description: The minimum number of master eligible nodes a node should "see" in order to operate within the cluster. Recommended to set it to a higher value than 1 when running more than 2 nodes in the cluster.
     default: 1

--- a/jobs/elasticsearch/templates/bin/elasticsearch_ctl
+++ b/jobs/elasticsearch/templates/bin/elasticsearch_ctl
@@ -47,7 +47,7 @@ case $1 in
     <% end %>
 
 
-    ulimit -n 64000
+    ulimit -n <%= p("elasticsearch.limits.fd") %>
     ulimit -l unlimited  # required to enable elasticsearch's mlockall setting
 
     mkdir -p $PLUGIN_SCRIPTS_DIR


### PR DESCRIPTION
Allow operators to configure max file descriptors, in case 64k isn't enough; default to the recommended value of 65536.

From https://www.elastic.co/guide/en/elasticsearch/guide/current/_file_descriptors_and_mmap.html:

> You should increase your file descriptor count to something very large, such as 64,000. This process is irritatingly difficult and highly dependent on your particular OS and distribution. Consult the documentation for your OS to determine how best to change the allowed file descriptor count.

cc @cnelson