### PR TITLE
[WIP] Add optional http health check for elasticsearch.

### DIFF
--- a/jobs/elasticsearch/monit
+++ b/jobs/elasticsearch/monit
@@ -1,16 +1,17 @@
-<% if p("elasticsearch.monitor.type") == "process") %>
+<% if p("elasticsearch.monitor.type") == "process" %>
 check process elasticsearch
   with pidfile /var/vcap/sys/run/elasticsearch/elasticsearch.pid
   start program "/var/vcap/jobs/elasticsearch/bin/monit_debugger elasticsearch_ctl '/var/vcap/jobs/elasticsearch/bin/elasticsearch_ctl start'" with timeout 120 seconds
   stop program "/var/vcap/jobs/elasticsearch/bin/monit_debugger elasticsearch_ctl '/var/vcap/jobs/elasticsearch/bin/elasticsearch_ctl stop'"
   group vcap
-<% else if p("elasticsearch.monitor.type") == "host" %>
+<% elsif p("elasticsearch.monitor.type") == "host" %>
 check host elasticsearch with address 127.0.0.1
   start program "/var/vcap/jobs/elasticsearch/bin/monit_debugger elasticsearch_ctl '/var/vcap/jobs/elasticsearch/bin/elasticsearch_ctl start'" with timeout 120 seconds
   stop program "/var/vcap/jobs/elasticsearch/bin/monit_debugger elasticsearch_ctl '/var/vcap/jobs/elasticsearch/bin/elasticsearch_ctl stop'"
   if failed url http://127.0.0.1:9200/_cluster/health
-    timeout <%= p("elasticsearch.monitor.timeout") %> seconds
-    for <%= p("elasticsearch.monitor.cycles") %> cycles
+    <% if p("elasticsearch.node.allow_data") and not p("elasticsearch.node.allow_master") %>and content = '"status":"green"'<% end %>
+    timeout <%= p("elasticsearch.monitor.host_timeout") %> seconds
+    for <%= p("elasticsearch.monitor.host_cycles") %> cycles
   then stop
   group vcap
 <% end %>

--- a/jobs/elasticsearch/monit
+++ b/jobs/elasticsearch/monit
@@ -1,8 +1,19 @@
+<% if p("elasticsearch.monitor.type") == "process") %>
 check process elasticsearch
   with pidfile /var/vcap/sys/run/elasticsearch/elasticsearch.pid
   start program "/var/vcap/jobs/elasticsearch/bin/monit_debugger elasticsearch_ctl '/var/vcap/jobs/elasticsearch/bin/elasticsearch_ctl start'" with timeout 120 seconds
   stop program "/var/vcap/jobs/elasticsearch/bin/monit_debugger elasticsearch_ctl '/var/vcap/jobs/elasticsearch/bin/elasticsearch_ctl stop'"
   group vcap
+<% else if p("elasticsearch.monitor.type") == "host" %>
+check host elasticsearch with address 127.0.0.1
+  start program "/var/vcap/jobs/elasticsearch/bin/monit_debugger elasticsearch_ctl '/var/vcap/jobs/elasticsearch/bin/elasticsearch_ctl start'" with timeout 120 seconds
+  stop program "/var/vcap/jobs/elasticsearch/bin/monit_debugger elasticsearch_ctl '/var/vcap/jobs/elasticsearch/bin/elasticsearch_ctl stop'"
+  if failed url http://127.0.0.1:9200/_cluster/health
+    timeout <%= p("elasticsearch.monitor.timeout") %> seconds
+    for <%= p("elasticsearch.monitor.cycles") %> cycles
+  then stop
+  group vcap
+<% end %>
 
 check device elasticsearch-ephemeral_disk with path /var/vcap/data
   if SPACE usage > 80% then alert

--- a/jobs/elasticsearch/spec
+++ b/jobs/elasticsearch/spec
@@ -40,6 +40,15 @@ properties:
   elasticsearch.limits.fd:
     description: Maximum file descriptors
     default: 65536
+  elasticsearch.monitor.type:
+    description: Monit check type; must be "process" or "host"
+    default: process
+  elasticsearch.monitor.host_timeout:
+    description: Host check timeout, in seconds
+    default: 15
+  elasticsearch.monitor.host_cycles:
+    description: Host check cycles
+    default: 5
   elasticsearch.discovery.minimum_master_nodes:
     description: The minimum number of master eligible nodes a node should "see" in order to operate within the cluster. Recommended to set it to a higher value than 1 when running more than 2 nodes in the cluster.
     default: 1


### PR DESCRIPTION
I'm labelling this as WIP because I want to do more testing before I call it ready, but feel free to review as-is.

As @cnelson noticed, the fact that the elasticsearch process is running
does not mean that elasticsearch is healthy. For example, if nodes are
out of memory or can't join the cluster, the process will be active, but
the node is not healthy. This patch adds the option to monitor
elasticsearch health via an http check instead of the default
process-based check.