### PR TITLE
Optionally compute minimum master nodes.

### DIFF
--- a/jobs/elasticsearch/spec
+++ b/jobs/elasticsearch/spec
@@ -42,7 +42,7 @@ properties:
     default: 65536
   elasticsearch.discovery.minimum_master_nodes:
     description: The minimum number of master eligible nodes a node should "see" in order to operate within the cluster. Recommended to set it to a higher value than 1 when running more than 2 nodes in the cluster.
-    default: 1
+    default: "auto"
   elasticsearch.config_options:
     description: "Additional options to append to elasticsearch's config.yml (YAML format)."
     default: ~

--- a/jobs/elasticsearch/templates/config/config.yml.erb
+++ b/jobs/elasticsearch/templates/config/config.yml.erb
@@ -20,7 +20,18 @@ node.<%= k %>: "<%= v %>"
 network.host: "0.0.0.0"
 http.host: <%= p("elasticsearch.http_host") %>
 
-discovery.zen.minimum_master_nodes: <%= p("elasticsearch.discovery.minimum_master_nodes") %>
+<%
+  minimum_master_nodes = p("elasticsearch.discovery.minimum_master_nodes")
+  if minimum_master_nodes == "auto"
+    masters = p("elasticsearch.master_hosts").length
+    if masters % 2 == 0
+      raise "Expected an odd number of masters; got #{masters}"
+    end
+    minimum_master_nodes = masters / 2 + 1
+  end
+%>
+
+discovery.zen.minimum_master_nodes: <%= minimum_master_nodes %>
 discovery.zen.ping.multicast.enabled: false
 discovery.zen.ping.unicast.hosts: "<%= p("elasticsearch.master_hosts").join(',') %>"
 


### PR DESCRIPTION
To help users avoid split brain when scaling masters.

cc @cnelson @rogeruiz