### PR TITLE
Delay allocation

### DIFF
--- a/jobs/elasticsearch/spec
+++ b/jobs/elasticsearch/spec
@@ -6,6 +6,7 @@ packages:
 - java8
 templates:
   bin/drain.erb: bin/drain
+  bin/post-start.erb: bin/post-start
   bin/post-deploy.erb: bin/post-deploy
   bin/elasticsearch_ctl: bin/elasticsearch_ctl
   bin/monit_debugger: bin/monit_debugger
@@ -30,6 +31,12 @@ properties:
   elasticsearch.node.allow_data:
     description: Allow node to store data? (true / false)
     default: false
+  elasticsearch.health.timeout:
+    description: Post-start timeout for node to join cluster
+    default: 300
+  elasticsearch.health.interval:
+    description: Post-start interval for node to join cluster
+    default: 15
   elasticsearch.node.tags:
     description: A hash of additional tags for the node
   elasticsearch.exec.environment:

--- a/jobs/elasticsearch/spec
+++ b/jobs/elasticsearch/spec
@@ -7,7 +7,6 @@ packages:
 templates:
   bin/drain.erb: bin/drain
   bin/post-start.erb: bin/post-start
-  bin/post-deploy.erb: bin/post-deploy
   bin/elasticsearch_ctl: bin/elasticsearch_ctl
   bin/monit_debugger: bin/monit_debugger
   config/config.yml.erb: config/elasticsearch.yml

--- a/jobs/elasticsearch/spec
+++ b/jobs/elasticsearch/spec
@@ -40,6 +40,12 @@ properties:
   elasticsearch.limits.fd:
     description: Maximum file descriptors
     default: 65536
+  elasticsearch.recovery.delay_allocation:
+    description: Delay allocation interval
+    default: "1m"
+  elasticsearch.recovery.delay_allocation_restart:
+    description: Delay allocation interval during restart
+    default: "5m"
   elasticsearch.discovery.minimum_master_nodes:
     description: The minimum number of master eligible nodes a node should "see" in order to operate within the cluster. Recommended to set it to a higher value than 1 when running more than 2 nodes in the cluster.
     default: 1

--- a/jobs/elasticsearch/templates/bin/drain.erb
+++ b/jobs/elasticsearch/templates/bin/drain.erb
@@ -6,10 +6,6 @@
 # changes to the elasticsearch nodes, so be sure elasticsearch jobs are
 # configured to deploy serially.
 #
-# When you get into fancier cluster scenarios, you'll want to disable this with
-# the `elasticsearch.drain: false` property and manage your own cluster
-# settings.
-#
 # This is invoked somewhere around here:
 # https://github.com/cloudfoundry/bosh/blob/7a7e42312a6a1dce50b578be579f17d10797e556/bosh_agent/lib/bosh_agent/message/drain.rb#L172
 #
@@ -19,11 +15,8 @@ set -u
 
 # disable allocations before bringing down data nodes
 <% if p('elasticsearch.node.allow_data') %>
-curl -s \
-    -X PUT \
-    -d '{"transient":{"cluster.routing.allocation.enable":"none"}}' \
-    'localhost:9200/_cluster/settings' \
-    > /dev/null
+curl -s -X PUT localhost:9200/_all/_settings \
+  -d '{"settings": {"index.unassigned.node_left.delayed_timeout": "<%= p("elasticsearch.recovery.delay_allocation_restart") %>"}}'
 <% end %>
 
 echo 0

--- a/jobs/elasticsearch/templates/bin/drain.erb
+++ b/jobs/elasticsearch/templates/bin/drain.erb
@@ -16,7 +16,8 @@ set -u
 # disable allocations before bringing down data nodes
 <% if p('elasticsearch.node.allow_data') %>
 curl -s -X PUT localhost:9200/_all/_settings \
-  -d '{"settings": {"index.unassigned.node_left.delayed_timeout": "<%= p("elasticsearch.recovery.delay_allocation_restart") %>"}}'
+  -d '{"settings": {"index.unassigned.node_left.delayed_timeout": "<%= p("elasticsearch.recovery.delay_allocation_restart") %>"}}' \
+  > /dev/null
 <% end %>
 
 echo 0

--- a/jobs/elasticsearch/templates/bin/post-deploy.erb
+++ b/jobs/elasticsearch/templates/bin/post-deploy.erb
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-set -e
-
-curl -s -X PUT localhost:9200/_all/_settings \
-  -d '{"settings": {"index.unassigned.node_left.delayed_timeout": "<%= p("elasticsearch.recovery.delay_allocation") %>"}}'

--- a/jobs/elasticsearch/templates/bin/post-deploy.erb
+++ b/jobs/elasticsearch/templates/bin/post-deploy.erb
@@ -2,8 +2,5 @@
 
 set -e
 
-curl -s \
-    -X PUT \
-    -d '{"transient":{"cluster.routing.allocation.enable":"all"}}' \
-    '<%= p('elasticsearch.master_hosts').first %>:9200/_cluster/settings' \
-    > /dev/null
+curl -s -X PUT localhost:9200/_all/_settings \
+  -d '{"settings": {"index.unassigned.node_left.delayed_timeout": "<%= p("elasticsearch.recovery.delay_allocation") %>"}}'

--- a/jobs/elasticsearch/templates/bin/post-start.erb
+++ b/jobs/elasticsearch/templates/bin/post-start.erb
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -e
+
+out=$(mktemp health-XXXXXX)
+remaining=<%= p("elasticsearch.health.timeout") %>
+
+until [ "${remaining}" -le 0 ]; do
+  curl -sw '\n%{http_code}' localhost:9200/_cluster/health > ${out}
+  body=$(cat ${out} | head -n -1)
+  status=$(cat ${out} | tail -n 1)
+  echo "body: ${body}"
+  echo "status: ${status}"
+  <% if p("elasticsearch.node.allow_data") and not p("elasticsearch.node.allow_master") %>
+  if [ ${status} = "200" ] && echo ${body} | grep '"status":"green"'; then
+    break
+  fi
+  <% else %>
+  if [ ${status} = "200" ]; then
+    break
+  fi
+  <% end %>
+  let remaining-=<%= p("elasticsearch.health.interval") %>
+  sleep <%= p("elasticsearch.health.interval") %>
+done
+
+rm ${out}
+
+if [ -z "${remaining}" ]; then
+  echo "Node failed to join the cluster"
+  exit 1
+fi

--- a/jobs/elasticsearch/templates/bin/post-start.erb
+++ b/jobs/elasticsearch/templates/bin/post-start.erb
@@ -6,7 +6,11 @@ out=$(mktemp health-XXXXXX)
 remaining=<%= p("elasticsearch.health.timeout") %>
 
 until [ "${remaining}" -le 0 ]; do
+  <% if p("elasticsearch.node.allow_data") and not p("elasticsearch.node.allow_master") %>
   curl -sw '\n%{http_code}' localhost:9200/_cluster/health > ${out}
+  <% else %>
+  curl -sw '\n%{http_code}' localhost:9200/_cluster/health?local=true > ${out}
+  <% end %>
   body=$(cat ${out} | head -n -1)
   status=$(cat ${out} | tail -n 1)
   echo "body: ${body}"

--- a/jobs/elasticsearch/templates/bin/post-start.erb
+++ b/jobs/elasticsearch/templates/bin/post-start.erb
@@ -30,3 +30,6 @@ if [ -z "${remaining}" ]; then
   echo "Node failed to join the cluster"
   exit 1
 fi
+
+curl -s -X PUT localhost:9200/_all/_settings \
+  -d '{"settings": {"index.unassigned.node_left.delayed_timeout": "<%= p("elasticsearch.recovery.delay_allocation") %>"}}'

--- a/jobs/elasticsearch/templates/bin/post-start.erb
+++ b/jobs/elasticsearch/templates/bin/post-start.erb
@@ -5,6 +5,11 @@ set -e
 out=$(mktemp health-XXXXXX)
 remaining=<%= p("elasticsearch.health.timeout") %>
 
+# Ensure shard allocation is enabled for updates from previous release
+# TODO: Deprecate on next release
+curl -X PUT -s <%= p('elasticsearch.master_hosts').first %>:9200/_cluster/settings \
+  -d '{"transient": {"cluster.routing.allocation.enable": "all"}}'
+
 until [ "${remaining}" -le 0 ]; do
   <% if p("elasticsearch.node.allow_data") and not p("elasticsearch.node.allow_master") %>
   curl -sw '\n%{http_code}' localhost:9200/_cluster/health > ${out}
@@ -35,5 +40,5 @@ if [ -z "${remaining}" ]; then
   exit 1
 fi
 
-curl -s -X PUT localhost:9200/_all/_settings \
+curl -X PUT -s localhost:9200/_all/_settings \
   -d '{"settings": {"index.unassigned.node_left.delayed_timeout": "<%= p("elasticsearch.recovery.delay_allocation") %>"}}'


### PR DESCRIPTION
As @cnelson described in https://github.com/18F/cg-product/issues/673#issuecomment-275785130, restarting the cluster can lead to outages for a few reasons:

* Since the monit health check on elastic verifies that the elastic process is running but not that the node has joined the cluster, bosh can start deploying the next node before the previous node has successfully joined the cluster.
* Since elastic defaults to a one-minute node timeout before reallocating shards, and restarting a node might take more than one minute, the cluster can frantically start reallocating shards for no reason.

This patch addresses both issues. We added a post-start script that blocks until the node is listening on 9200--and, for data nodes, until the cluster is healthy. We also optionally increase the node timeout on drain, then restore it on post-deploy, to avoid "shard shuffle". This also means we don't need to rely on shard routing settings to keep the cluster healthy during restarts: https://github.com/elastic/elasticsearch/issues/19739.