### PR TITLE
Skip delay allocation on parser nodes

### DIFF
--- a/jobs/elasticsearch/templates/bin/post-start.erb
+++ b/jobs/elasticsearch/templates/bin/post-start.erb
@@ -40,5 +40,7 @@ if [ -z "${remaining}" ]; then
   exit 1
 fi
 
+<% if p("elasticsearch.node.allow_data") %>
 curl -X PUT -s localhost:9200/_all/_settings \
   -d '{"settings": {"index.unassigned.node_left.delayed_timeout": "<%= p("elasticsearch.recovery.delay_allocation") %>"}}'
+<% end %>


### PR DESCRIPTION
Don't update `index.unassigned.node_left.delayed_timeout` setting from parser nodes. Discussed in https://github.com/cloudfoundry-community/logsearch-boshrelease/issues/45.
/cc @jmcarp 