### PR TITLE
Add option to disable Redis Queue AOF persistence

### DIFF
--- a/jobs/queue/spec
+++ b/jobs/queue/spec
@@ -24,3 +24,6 @@ properties:
   redis.maxmemory-policy:
     description: How Redis will select what to remove when maxmemory is reached. Possible values are volatile-lru, allkeys-lru, volatile-random, allkeys-random, volatile-ttl, and noeviction.
     default: volatile-lru
+  redis.appendonly:
+    description: Enable Redis Persistence through AOF file
+    default: yes

--- a/jobs/queue/templates/config/redis.conf.erb
+++ b/jobs/queue/templates/config/redis.conf.erb
@@ -465,7 +465,7 @@ maxmemory-policy <%= p("redis.maxmemory-policy") %>
 #
 # Please check http://redis.io/topics/persistence for more information.
 
-appendonly yes
+appendonly <%= p("redis.appendonly") %>
 
 # The name of the append only file (default: "appendonly.aof")
 appendfilename "redis-appendonly.aof"


### PR DESCRIPTION
We've noticed that in an extremely busy CF environment which generates a massive amount of logs, the Redis Queue VM would crash every few days because of the huge AOF file for persistence (/var/vcap/store/queue/redis-appendonly.aof) using 100% persistent disk which would prevent logs from being parsed into ELK.

I tested it and disabling this option appears to have stabilized it and the ELK stack has been running smooth for the past few days. If it's OK, this change can be merged into the main branch.

Thanks & Regards,
Moiz Khan