### PR TITLE
Add plugin installing code into elasticsearch_ctl and Redis AOF fix

### DIFF
--- a/jobs/elasticsearch/templates/bin/elasticsearch_ctl
+++ b/jobs/elasticsearch/templates/bin/elasticsearch_ctl
@@ -40,7 +40,16 @@ case $1 in
 
     # install plugins
     rm -rf /var/vcap/packages/elasticsearch/plugins/*
-
+    <% p("elasticsearch.plugins").each do |plugin| name, path = plugin.first %>
+      <% if path.start_with? '/var/vcap' %>
+        /var/vcap/packages/elasticsearch/bin/elasticsearch-plugin install "file://<%= path %>"
+      <% elsif path.start_with? 'http' %>
+        /var/vcap/packages/elasticsearch/bin/elasticsearch-plugin install "<%= path %>"
+      <% else %>
+        /var/vcap/packages/elasticsearch/bin/elasticsearch-plugin install "<%= path %>"
+      <% end %>
+    <% end %>
+    
     if [ -n "$MAX_OPEN_FILES" ]; then
       ulimit -n $MAX_OPEN_FILES
     fi

--- a/jobs/queue/spec
+++ b/jobs/queue/spec
@@ -24,3 +24,6 @@ properties:
   redis.maxmemory-policy:
     description: How Redis will select what to remove when maxmemory is reached. Possible values are volatile-lru, allkeys-lru, volatile-random, allkeys-random, volatile-ttl, and noeviction.
     default: volatile-lru
+  redis.appendonly:
+    description: Enable Redis Persistence through AOF file
+    default: yes

--- a/jobs/queue/spec
+++ b/jobs/queue/spec
@@ -26,4 +26,4 @@ properties:
     default: volatile-lru
   redis.appendonly:
     description: Enable Redis Persistence through AOF file
-    default: yes
+    default: "yes"

--- a/jobs/queue/templates/config/redis.conf.erb
+++ b/jobs/queue/templates/config/redis.conf.erb
@@ -465,7 +465,7 @@ maxmemory-policy <%= p("redis.maxmemory-policy") %>
 #
 # Please check http://redis.io/topics/persistence for more information.
 
-appendonly yes
+appendonly <%= p("redis.appendonly") %>
 
 # The name of the append only file (default: "appendonly.aof")
 appendfilename "redis-appendonly.aof"


### PR DESCRIPTION
Add plugin installation code for those using elasticsearch plugins like x-pack or others. Also, put the default 'appendonly' value in quotes otherwise BOSH interprets this as boolean and puts true/false instead causing queue process to fail