### PR TITLE
add post-start health check for kibana

### DIFF
--- a/jobs/kibana/spec
+++ b/jobs/kibana/spec
@@ -9,6 +9,7 @@ templates:
   data/properties.sh.erb: "data/properties.sh"
   helpers/ctl_setup.sh: "helpers/ctl_setup.sh"
   helpers/ctl_utils.sh: "helpers/ctl_utils.sh"
+  bin/post-start.erb: bin/post-start
 properties:
   kibana.elasticsearch.host:
     description: "IP address of elasticsearch master to send elasticsearch requests to"
@@ -52,3 +53,6 @@ properties:
   kibana.wait_for_templates:
     description: "A list of index templates that need to be present in ElasticSearch before the process starts"
     default: []
+  kibana.health.disable_post_start:
+    description: Allow node to run post-start script? (true / false)
+    default: false

--- a/jobs/kibana/templates/bin/post-start.erb
+++ b/jobs/kibana/templates/bin/post-start.erb
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -e
+
+<% if !p("kibana.health.disable_post_start") %>
+
+echo "Waiting 2m for kibana to accept connections..."
+n=0
+until [ $n -ge 24 ]
+do
+  curl -is http://<%= p("kibana.host") %>:<%= p("kibana.port") %> 2>&1 && break
+  n=$[$n+1]
+  echo "Waiting for kibana to accept connections ($n of 24)..."
+  sleep 5
+done
+
+if [ "$n" -ge "24" ]; then
+   echo "ERROR: Cannot connect to kibana. Exiting..."
+   exit 1
+fi
+
+<% end %>
+
+exit 0


### PR DESCRIPTION
Kibana's startup process frequently takes over 60 seconds from the time monit thinks it's started (pid file exists) until it's actually able to accept connections. This can lead to 503s from haproxy  as bosh will not wait for kibana to be actually running before moving on to updating the next instance.

This PR adds a post-start health check to kibana which waits for it to accepting connections before marking it up.  The logic from this health check was taken directly from the elasticsearch job's post-start check.

cc: @jmcarp @rogeruiz
