### PR TITLE
Accept external kibana configuration.

### DIFF
--- a/jobs/kibana/spec
+++ b/jobs/kibana/spec
@@ -1,7 +1,7 @@
 ---
 name: "kibana"
 packages:
-  - "kibana"
+- "kibana"
 templates:
   bin/kibana_ctl: "bin/kibana_ctl"
   config/kibana.conf.erb: "config/kibana.conf"
@@ -37,6 +37,9 @@ properties:
     default: 30000
   kibana.env:
     description: "a list of arbitrary key-value pairs to be passed on as process environment variables. eg: FOO: 123"
+    default: []
+  kibana.source_files:
+    description: "List of files to source in kibana control script"
     default: []
   kibana.console_enabled:
     description: "Enable Kibana development console; should be set to `false` in a multi-tenant deployment."

--- a/jobs/kibana/templates/bin/kibana_ctl
+++ b/jobs/kibana/templates/bin/kibana_ctl
@@ -41,6 +41,10 @@ case $1 in
     export <%= env.keys[0] %>="<%= env.values[0] %>"
     <% end %>
 
+    <% p("kibana.source_files").each do |sf| %>
+    source <%= sf %>
+    <% end %>
+
     rm -rf /var/vcap/packages/kibana/plugins/*
     <% p("kibana.plugins").each do |plugin| name, path = plugin.first %>
       <% if path.start_with? '/var/vcap' %>


### PR DESCRIPTION
Required for https://github.com/cloudfoundry-community/logsearch-for-cloudfoundry/pull/260, for example.