### PR TITLE
Parameterize kibana health check.

### DIFF
--- a/jobs/elasticsearch/spec
+++ b/jobs/elasticsearch/spec
@@ -36,11 +36,17 @@ properties:
     description: Allow node to store data? (true / false)
     default: false
   elasticsearch.health.timeout:
-    description: Post-start timeout for node to join cluster
+    description: Post-start timeout for node to join cluster (seconds)
     default: 300
   elasticsearch.health.interval:
-    description: Post-start interval for node to join cluster
+    description: Post-start interval for node to join cluster (seconds)
     default: 15
+  elasticsearch.health.connect_timeout:
+    description: Post-start timeout for node to become available (seconds)
+    default: 60
+  elasticsearch.health.connect_interval:
+    description: Post-start interval for node to become available (seconds)
+    default: 5
   elasticsearch.node.tags:
     description: A hash of additional tags for the node
   elasticsearch.exec.environment:

--- a/jobs/elasticsearch/templates/bin/post-start.erb
+++ b/jobs/elasticsearch/templates/bin/post-start.erb
@@ -4,17 +4,16 @@ set -e
 
 <% if !p("elasticsearch.health.disable_post_start") %>
 
-echo "Waiting 1m for elasticsearch to accept connections..."
-n=0
-until [ $n -ge 12 ]
+echo "Waiting <%= p("elasticsearch.health.connect_timeout") %>s for elasticsearch to accept connections..."
+elapsed=0
+until [ $elapsed -ge <%= p("elasticsearch.health.connect_timeout") %> ]
 do
   nc -4 -z -v localhost 9200 2>&1 && break
-  n=$[$n+1]
-  echo "Waiting for elasticsearch to accept connections ($n of 12)..."
-  sleep 5
+  elapsed=$[$elapsed+<%= p("elasticsearch.health.connect_interval") %>]
+  sleep <%= p("elasticsearch.health.connect_interval") %>
 done
 
-if [ "$n" -ge "12" ]; then
+if [ "$elapsed" -ge "<%= p("elasticsearch.health.connect_timeout") %>" ]; then
    echo "ERROR: Cannot connect to elasticsearch. Exiting..."
    exit 1
 fi

--- a/jobs/kibana/spec
+++ b/jobs/kibana/spec
@@ -59,3 +59,9 @@ properties:
   kibana.health.disable_post_start:
     description: Allow node to run post-start script? (true / false)
     default: false
+  kibana.health.interval:
+    description: Kibana health check interval (seconds)
+    default: 5
+  kibana.health.timeout:
+    description: Kibana health check number of attempts (seconds)
+    default: 180

--- a/jobs/kibana/templates/bin/post-start.erb
+++ b/jobs/kibana/templates/bin/post-start.erb
@@ -4,19 +4,18 @@ set -e
 
 <% if !p("kibana.health.disable_post_start") %>
 
-echo "Waiting 2m for kibana to accept connections..."
-n=0
-until [ $n -ge 24 ]
+echo "Waiting <%= p("kibana.health.timeout") %>s for kibana to accept connections..."
+elapsed=0
+until [ $elapsed -ge <%= p("kibana.health.timeout") %> ]
 do
   curl -is http://<%= p("kibana.host") %>:<%= p("kibana.port") %> 2>&1 && break
-  n=$[$n+1]
-  echo "Waiting for kibana to accept connections ($n of 24)..."
-  sleep 5
+  elapsed=$[$elapsed+<%= p("kibana.health.interval") %>]
+  sleep <%= p("kibana.health.interval") %>
 done
 
-if [ "$n" -ge "24" ]; then
-   echo "ERROR: Cannot connect to kibana. Exiting..."
-   exit 1
+if [ "$elapsed" -ge "<%= p("kibana.health.timeout") %>" ]; then
+  echo "ERROR: Cannot connect to kibana. Exiting..."
+  exit 1
 fi
 
 <% end %>


### PR DESCRIPTION
Health checks should be controlled via job properties and use consistently named parameters.

cc @cnelson