### PR TITLE
Clear all existing templates before uploading new ones.

### DIFF
--- a/jobs/elasticsearch_config/templates/bin/run.erb
+++ b/jobs/elasticsearch_config/templates/bin/run.erb
@@ -2,6 +2,12 @@
 
 set -e
 
+# Delete existing templates before uploading
+URL=http://<%= p('elasticsearch_config.elasticsearch.host') %>:<%= p('elasticsearch_config.elasticsearch.port') %>
+for template in $(curl -s ${URL}/_template?pretty | grep -e '^\s\s"' | awk -F '"' '{print $2}'); do
+  curl -XDELETE ${URL}/_template/${template}
+done
+
 <%
 # Look ma, I'm writing Chef
 require 'uri'

--- a/jobs/elasticsearch_config/templates/bin/run.erb
+++ b/jobs/elasticsearch_config/templates/bin/run.erb
@@ -1,11 +1,13 @@
-#!/bin/bash -x
+#!/bin/bash
 
-set -e
+set -ex
 
 # Delete existing templates before uploading
 URL=http://<%= p('elasticsearch_config.elasticsearch.host') %>:<%= p('elasticsearch_config.elasticsearch.port') %>
-for template in $(curl -s ${URL}/_template?pretty | grep -e '^\s\s"' | awk -F '"' '{print $2}'); do
-  curl -XDELETE ${URL}/_template/${template}
+for template in $(curl -s ${URL}/_cat/templates | awk '{print $1}'); do
+  if ! grep -qw ${template} <(echo "<%= p('elasticsearch_config.templates').map { |template| template.keys.first }.join(' ') %>"); then
+    curl -XDELETE ${URL}/_template/${template}
+  fi
 done
 
 <%


### PR DESCRIPTION
We currently update existing templates using `elasticsearch_config`, but
if old templates are dropped from the release, they will never be
cleared from elasticsearch. For example, the `index_pattern` template
was removed in
https://github.com/cloudfoundry-community/logsearch-for-cloudfoundry/pull/242
but still existed in our cluster until we deleted it manually.

Pairing with @wjwoodson @rogeruiz