### PR TITLE
Move node attributes to node.attr. namespace

### DIFF
--- a/jobs/elasticsearch/templates/config/config.yml.erb
+++ b/jobs/elasticsearch/templates/config/config.yml.erb
@@ -12,7 +12,7 @@ node.name: "<%= name %>/<%= index %>"
 node.master: <%= p("elasticsearch.node.allow_master") %>
 node.data: <%= p("elasticsearch.node.allow_data") %>
 <% p("elasticsearch.node.tags", {}).each do | k, v | %>
-node.<%= k %>: "<%= v %>"
+node.attr.<%= k %>: "<%= v %>"
 <% end %>
 
 network.host: "0.0.0.0"


### PR DESCRIPTION
Node level attributes used for allocation filtering, forced awareness or other node identification / grouping must be prefixed with node.attr [1].

[1]- https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking_50_settings_changes.html#_node_attribute_settings