### PR TITLE
Drop default cerebro secret.

### DIFF
--- a/deployment/logsearch-deployment.yml
+++ b/deployment/logsearch-deployment.yml
@@ -96,6 +96,9 @@ instance_groups:
     release: logsearch
     consumes:
       elasticsearch: {from: elasticsearch_master}
+    properties:
+      cerebro:
+        secret: ((cerebro_secret_key))
   - name: syslog_forwarder
     release: logsearch
     consumes:
@@ -400,6 +403,8 @@ variables:
 - name: kibana_oauth2_client_secret
   type: password
 - name: firehose_client_secret
+  type: password
+- name: cerebro_secret_key
   type: password
 
 releases:

--- a/jobs/cerebro/spec
+++ b/jobs/cerebro/spec
@@ -27,4 +27,3 @@ properties:
     default: []
   cerebro.secret:
     description: Secret will be used to sign Cerebro session cookies and CSRF tokens.
-    default: "ABCDEFGHIJKLMNOPQRSTUVWXYZ"

--- a/jobs/cerebro/templates/config/application.conf.erb
+++ b/jobs/cerebro/templates/config/application.conf.erb
@@ -1,5 +1,4 @@
 # Secret will be used to sign session cookies, CSRF tokens and for other encryption utilities.
-# It is highly recommended to change this value before running cerebro in production.
 secret = "<%= p("cerebro.secret") %>"
 
 # Application base path

--- a/templates/logsearch-jobs.yml
+++ b/templates/logsearch-jobs.yml
@@ -22,6 +22,8 @@ jobs:
       node:
         allow_master: true
         allow_data: false
+    cerebro:
+      secret: (( param "specify cerebro secret key" ))
     syslog_forwarder:
       config:
       - {service: elasticsearch, file: /var/vcap/sys/log/elasticsearch/elasticsearch.stdout.log}


### PR DESCRIPTION
Let's require operators who want cerebro to set a non-default secret instead of recommending it in a comment 😃 