### PR TITLE
Add archiver syslog job.

### DIFF
--- a/jobs/archiver_syslog/monit
+++ b/jobs/archiver_syslog/monit
@@ -1,0 +1,5 @@
+check process archiver_syslog
+  with pidfile /var/vcap/sys/run/archiver_syslog/archiver_syslog.pid
+  start program "/var/vcap/jobs/archiver_syslog/bin/monit_debugger archiver_syslog_ctl '/var/vcap/jobs/archiver_syslog/bin/archiver_syslog_ctl start'"  with timeout 120 seconds
+  stop program "/var/vcap/jobs/archiver_syslog/bin/monit_debugger archiver_syslog_ctl '/var/vcap/jobs/archiver_syslog/bin/archiver_syslog_ctl stop'"
+  group vcap

--- a/jobs/archiver_syslog/spec
+++ b/jobs/archiver_syslog/spec
@@ -54,6 +54,8 @@ properties:
   logstash_ingestor.workers:
     description: "The number of worker threads that logstash should use (default: auto = one per CPU)"
     default: auto
+  logstash_ingestor.filters:
+    description: Filters to execute on the ingestors
 
   logstash.queue.type:
     description: Internal queuing model, "memory" for legacy in-memory based queuing and "persisted" for disk-based acked queueing.

--- a/jobs/archiver_syslog/spec
+++ b/jobs/archiver_syslog/spec
@@ -1,0 +1,103 @@
+---
+name: archiver_syslog
+
+packages:
+- logstash
+- logsearch-config
+- java8
+
+templates:
+  bin/archiver_syslog_ctl: bin/archiver_syslog_ctl
+  bin/monit_debugger: bin/monit_debugger
+  config/input_and_output.conf.erb: config/input_and_output.conf
+  config/syslog_tls.crt.erb: config/syslog_tls.crt
+  config/syslog_tls.key.erb: config/syslog_tls.key
+  config/logstash.yml.erb: config/logstash.yml
+  data/properties.sh.erb: data/properties.sh
+  helpers/ctl_setup.sh: helpers/ctl_setup.sh
+  helpers/ctl_utils.sh: helpers/ctl_utils.sh
+
+provides:
+- name: archiver
+  type: archiver
+  properties:
+  - logstash_ingestor.syslog.port
+  - logstash_ingestor.syslog.transport
+  - logstash_ingestor.syslog_tls.port
+  - logstash_ingestor.relp.port
+- name: syslog_forwarder
+  type: syslog_forwarder
+  properties:
+  - logstash_ingestor.syslog.port
+
+properties:
+  logstash.heap_size:
+    description: sets jvm heap sized
+  logstash.metadata_level:
+    description: "Whether to include additional metadata throughout the event lifecycle. NONE = disabled, DEBUG = fully enabled"
+    default: "NONE"
+  logstash.log_level:
+    description: The default logging level (e.g. WARN, DEBUG, INFO)
+    default: info
+  logstash.plugins:
+    description: "Array of hashes describing logstash plugins to install"
+    example:
+    - {name: logstash-output-cloudwatchlogs, version: 2.0.0}
+    default: []
+  logstash.env:
+    description: "a list of arbitrary key-value pairs to be passed on as process environment variables. eg: FOO: 123"
+    default: []
+
+  logstash_ingestor.debug:
+    description: Debug level logging
+    default: false
+  logstash_ingestor.workers:
+    description: "The number of worker threads that logstash should use (default: auto = one per CPU)"
+    default: auto
+
+  logstash.queue.type:
+    description: Internal queuing model, "memory" for legacy in-memory based queuing and "persisted" for disk-based acked queueing.
+    default: persisted
+  logstash.queue.page_capacity:
+    description: The page data files size. The queue data consists of append-only data files separated into pages.
+    default: 250mb
+  logstash.queue.max_events:
+    description: The maximum number of unread events in the queue.
+    default: 0
+  logstash.queue.max_bytes:
+    description: The total capacity of the queue in number of bytes.
+    default: 1024mb
+  logstash.queue.checkpoint.acks:
+    description: The maximum number of acked events before forcing a checkpoint.
+    default: 1024
+  logstash.queue.checkpoint.writes:
+    description: The maximum number of written events before forcing a checkpoint.
+    default: 1024
+  logstash.queue.checkpoint.interval:
+    description: The interval in milliseconds when a checkpoint is forced on the head page.
+    default: 1000
+
+  logstash_ingestor.syslog.port:
+    description: Port to listen for syslog messages
+    default: 5514
+  logstash_ingestor.syslog.transport:
+    description: Transport protocol to use
+    default: "tcp"
+
+  logstash_ingestor.syslog_tls.port:
+    description: Port to listen for syslog-TLS messages (omit to disable)
+  logstash_ingestor.syslog_tls.ssl_cert:
+    description: Syslog-TLS SSL certificate (file contents, not a path) - required if logstash_ingestor.syslog_tls.port set
+  logstash_ingestor.syslog_tls.ssl_key:
+    description: Syslog-TLS SSL key (file contents, not a path) - required if logstash_ingestor.syslog_tls.port set
+  logstash_ingestor.syslog_tls.skip_ssl_validation:
+    description: Verify the identity of the other end of the SSL connection against the CA.
+    default: false
+
+  logstash_ingestor.relp.port:
+    description: Port to listen for RELP messages
+    default: 2514
+
+  logstash_ingestor.outputs:
+    description: A list of output plugins, with a hash of options for each of them.
+    default: []

--- a/jobs/archiver_syslog/templates/bin/archiver_syslog_ctl
+++ b/jobs/archiver_syslog/templates/bin/archiver_syslog_ctl
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+set -e # exit immediately if a simple command exits with a non-zero status
+set -u # report the usage of uninitialized variables
+
+# Setup env vars and folders for the webapp_ctl script
+source /var/vcap/jobs/archiver_syslog/helpers/ctl_setup.sh 'archiver_syslog'
+
+export PORT=${PORT:-5000}
+export LANG=en_US.UTF-8
+<% if 'auto' == p('logstash_ingestor.workers') %>
+# 1 logstash worker / CPU core
+export LOGSTASH_WORKERS=`grep -c ^processor /proc/cpuinfo`
+<% else %>
+export LOGSTASH_WORKERS=<%= p('logstash_ingestor.workers') %>
+<% end %>
+export HEAP_SIZE=$((( $( cat /proc/meminfo | grep MemTotal | awk '{ print $2 }' ) * 46 ) / 100 ))K
+<% if_p('logstash.heap_size') do |heap_size| %>
+HEAP_SIZE=<%= heap_size %>
+<% end %>
+<% p("logstash.env").each do |env| %>
+export <%= env.keys[0] %>="<%= env.values[0] %>"
+<% end %>
+
+case $1 in
+
+  start)
+    pid_guard $PIDFILE $JOB_NAME
+
+    # store this processes pid in $PIDFILE, since the exec below doesn't daemonize
+    echo $$ > $PIDFILE
+
+    export LS_JAVA_OPTS="-Xms$HEAP_SIZE -Xmx$HEAP_SIZE -DPID=$$"
+
+    <% p("logstash.plugins").each do |plugin| %>
+    /var/vcap/packages/logstash/bin/logstash-plugin install \
+      <%= plugin.except("name").map { |key, value| "--#{key}=#{value}" }.join(" ") %> \
+      <%= plugin["name"] %>
+    <% end %>
+
+    # construct a complete config file from all the fragments
+    cat ${JOB_DIR}/config/input_and_output.conf > ${JOB_DIR}/config/logstash.conf
+
+    exec chpst -u vcap:vcap /var/vcap/packages/logstash/bin/logstash \
+        --path.data ${STORE_DIR} \
+        --path.config ${JOB_DIR}/config/logstash.conf \
+        --path.settings ${JOB_DIR}/config \
+        --pipeline.workers ${LOGSTASH_WORKERS} \
+        --log.format=json --log.level=<%= p("logstash.log_level") %> \
+         >>$LOG_DIR/$JOB_NAME.stdout.log \
+         2>>$LOG_DIR/$JOB_NAME.stderr.log
+
+    ;;
+
+  stop)
+    kill_and_wait $PIDFILE
+    ensure_no_more_logstash
+
+    ;;
+  *)
+    echo "Usage: archiver_syslog_ctl {start|stop}"
+
+    ;;
+
+esac
+exit 0

--- a/jobs/archiver_syslog/templates/bin/monit_debugger
+++ b/jobs/archiver_syslog/templates/bin/monit_debugger
@@ -1,0 +1,13 @@
+#!/bin/sh
+# USAGE monit_debugger <label> command to run
+mkdir -p /var/vcap/sys/log/monit
+{
+  echo "MONIT-DEBUG date"
+  date
+  echo "MONIT-DEBUG env"
+  env
+  echo "MONIT-DEBUG $@"
+  $2 $3 $4 $5 $6 $7
+  R=$?
+  echo "MONIT-DEBUG exit code $R"
+} >/var/vcap/sys/log/monit/monit_debugger.$1.log 2>&1

--- a/jobs/archiver_syslog/templates/config/input_and_output.conf.erb
+++ b/jobs/archiver_syslog/templates/config/input_and_output.conf.erb
@@ -40,6 +40,7 @@ filter {
   ruby {
     code => 'event.cancel if event.get("message") == "\u0000"'
   }
+  <%= if_p('logstash_ingestor.filters') do |filters| %><%= filters %><% end %>
 }
 
 output {

--- a/jobs/archiver_syslog/templates/config/input_and_output.conf.erb
+++ b/jobs/archiver_syslog/templates/config/input_and_output.conf.erb
@@ -1,0 +1,59 @@
+input {
+  <% if p("logstash_ingestor.syslog.port") %>
+  tcp {
+    add_field => [ "type", "syslog" ]
+    host => "0.0.0.0"
+    port => "<%= p("logstash_ingestor.syslog.port") %>"
+  }
+  udp {
+    add_field => [ "type", "syslog" ]
+    host => "0.0.0.0"
+    port => "<%= p("logstash_ingestor.syslog.port") %>"
+  }
+  <% end %>
+
+  <% if_p("logstash_ingestor.syslog_tls.port") do | port | %>
+  tcp {
+    add_field => [ "type", "syslog" ]
+    host => "0.0.0.0"
+    port => "<%= port %>"
+    ssl_enable => true
+    <% if p("logstash_ingestor.syslog_tls.skip_ssl_validation") %>
+    ssl_verify => false
+    <% end %>
+    ssl_cert => "/var/vcap/jobs/ingestor_syslog/config/syslog_tls.crt"
+    ssl_key => "/var/vcap/jobs/ingestor_syslog/config/syslog_tls.key"
+  }
+  <% end %>
+
+  <% if_p("logstash_ingestor.relp.port") do | port | %>
+  relp {
+    add_field => { "_logstash_input" => "relp" }
+    host => "0.0.0.0"
+    port => "<%= port %>"
+  }
+  <% end %>
+}
+
+filter {
+  # drop empty logs (eg: monit connection healthcheck)
+  ruby {
+    code => 'event.cancel if event.get("message") == "\u0000"'
+  }
+}
+
+output {
+    <% if p("logstash_ingestor.debug") %>
+        stdout {
+            codec => "json"
+        }
+    <% end %>
+
+    <% p('logstash_ingestor.outputs').each do | output | %>
+        <%= output['plugin'] %> {
+        <% output['options'].each do | k, v | %>
+          <%= k %> => <%= v.inspect %>
+        <% end %>
+        }
+    <% end %>
+}

--- a/jobs/archiver_syslog/templates/config/logstash.yml.erb
+++ b/jobs/archiver_syslog/templates/config/logstash.yml.erb
@@ -1,0 +1,9 @@
+# ------------ Queuing Settings --------------
+
+queue.type: <%= p("logstash.queue.type") %>
+queue.page_capacity: <%= p("logstash.queue.page_capacity") %>
+queue.max_events: <%= p("logstash.queue.max_events") %>
+queue.max_bytes: <%= p("logstash.queue.max_bytes") %>
+queue.checkpoint.acks: <%= p("logstash.queue.checkpoint.acks") %>
+queue.checkpoint.writes: <%= p("logstash.queue.checkpoint.writes") %>
+queue.checkpoint.interval: <%= p("logstash.queue.checkpoint.interval") %>

--- a/jobs/archiver_syslog/templates/config/syslog_tls.crt.erb
+++ b/jobs/archiver_syslog/templates/config/syslog_tls.crt.erb
@@ -1,0 +1,1 @@
+<% if_p("logstash_ingestor.syslog_tls.ssl_cert") do | ssl | %><%= ssl %><% end %>

--- a/jobs/archiver_syslog/templates/config/syslog_tls.key.erb
+++ b/jobs/archiver_syslog/templates/config/syslog_tls.key.erb
@@ -1,0 +1,1 @@
+<% if_p("logstash_ingestor.syslog_tls.ssl_key") do | ssl | %><%= ssl %><% end %>

--- a/jobs/archiver_syslog/templates/data/properties.sh.erb
+++ b/jobs/archiver_syslog/templates/data/properties.sh.erb
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+# job template binding variables
+
+# job name & index of this VM within cluster
+# e.g. JOB_NAME=redis, JOB_INDEX=0
+export NAME='<%= name %>'
+export JOB_INDEX=<%= index %>
+# full job name, like redis/0 or webapp/3
+export JOB_FULL="$NAME/$JOB_INDEX"

--- a/jobs/archiver_syslog/templates/helpers/ctl_setup.sh
+++ b/jobs/archiver_syslog/templates/helpers/ctl_setup.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+
+# Setup env vars and folders for the ctl script
+# This helps keep the ctl script as readable
+# as possible
+
+# Usage options:
+# source /var/vcap/jobs/foobar/helpers/ctl_setup.sh JOB_NAME OUTPUT_LABEL
+# source /var/vcap/jobs/foobar/helpers/ctl_setup.sh foobar
+# source /var/vcap/jobs/foobar/helpers/ctl_setup.sh foobar foobar
+# source /var/vcap/jobs/foobar/helpers/ctl_setup.sh foobar nginx
+
+set -e # exit immediately if a simple command exits with a non-zero status
+set -u # report the usage of uninitialized variables
+
+JOB_NAME=$1
+output_label=${1:-JOB_NAME}
+
+export JOB_DIR=/var/vcap/jobs/$JOB_NAME
+chmod 755 $JOB_DIR # to access file via symlink
+
+# Load some bosh deployment properties into env vars
+# Try to put all ERb into data/properties.sh.erb
+# incl $NAME, $JOB_INDEX, $WEBAPP_DIR
+source $JOB_DIR/data/properties.sh
+
+source $JOB_DIR/helpers/ctl_utils.sh
+redirect_output ${output_label}
+
+export HOME=${HOME:-/home/vcap}
+
+# Add all packages' /bin & /sbin into $PATH
+for package_bin_dir in $(ls -d /var/vcap/packages/*/*bin)
+do
+  export PATH=${package_bin_dir}:$PATH
+done
+
+export LD_LIBRARY_PATH=${LD_LIBRARY_PATH:-''} # default to empty
+for package_bin_dir in $(ls -d /var/vcap/packages/*/lib)
+do
+  export LD_LIBRARY_PATH=${package_bin_dir}:$LD_LIBRARY_PATH
+done
+
+# Setup log, run and tmp folders
+
+export RUN_DIR=/var/vcap/sys/run/$JOB_NAME
+export LOG_DIR=/var/vcap/sys/log/$JOB_NAME
+export TMP_DIR=/var/vcap/sys/tmp/$JOB_NAME
+export STORE_DIR=/var/vcap/store/$JOB_NAME
+export DATA_DIR=/var/vcap/data/$JOB_NAME
+for dir in $RUN_DIR $LOG_DIR $TMP_DIR $STORE_DIR $DATA_DIR
+do
+  mkdir -p ${dir}
+  chown vcap:vcap ${dir}
+  chmod 775 ${dir}
+done
+export TMPDIR=$TMP_DIR
+
+export C_INCLUDE_PATH=/var/vcap/packages/mysqlclient/include/mysql:/var/vcap/packages/sqlite/include:/var/vcap/packages/libpq/include
+export LIBRARY_PATH=/var/vcap/packages/mysqlclient/lib/mysql:/var/vcap/packages/sqlite/lib:/var/vcap/packages/libpq/lib
+
+# consistent place for vendoring python libraries within package
+if [[ -d ${WEBAPP_DIR:-/xxxx} ]]
+then
+  export PYTHONPATH=$WEBAPP_DIR/vendor/lib/python
+fi
+
+if [[ -d /var/vcap/packages/java8 ]]
+then
+  export JAVA_HOME="/var/vcap/packages/java8"
+fi
+
+PIDFILE=$RUN_DIR/$JOB_NAME.pid
+
+echo '$PATH' $PATH

--- a/jobs/archiver_syslog/templates/helpers/ctl_utils.sh
+++ b/jobs/archiver_syslog/templates/helpers/ctl_utils.sh
@@ -1,0 +1,189 @@
+# Helper functions used by ctl scripts
+
+# links a job file (probably a config file) into a package
+# Example usage:
+# link_job_file_to_package config/redis.yml [config/redis.yml]
+# link_job_file_to_package config/wp-config.php wp-config.php
+link_job_file_to_package() {
+  source_job_file=$1
+  target_package_file=${2:-$source_job_file}
+  full_package_file=$WEBAPP_DIR/${target_package_file}
+
+  link_job_file ${source_job_file} ${full_package_file}
+}
+
+# links a job file (probably a config file) somewhere
+# Example usage:
+# link_job_file config/bashrc /home/vcap/.bashrc
+link_job_file() {
+  source_job_file=$1
+  target_file=$2
+  full_job_file=$JOB_DIR/${source_job_file}
+
+  echo link_job_file ${full_job_file} ${target_file}
+  if [[ ! -f ${full_job_file} ]]
+  then
+    echo "file to link ${full_job_file} does not exist"
+  else
+    # Create/recreate the symlink to current job file
+    # If another process is using the file, it won't be
+    # deleted, so don't attempt to create the symlink
+    mkdir -p $(dirname ${target_file})
+    ln -nfs ${full_job_file} ${target_file}
+  fi
+}
+
+# If loaded within monit ctl scripts then pipe output
+# If loaded from 'source ../utils.sh' then normal STDOUT
+redirect_output() {
+  SCRIPT=$1
+  mkdir -p /var/vcap/sys/log/monit
+  exec 1>> /var/vcap/sys/log/monit/$SCRIPT.log
+  exec 2>> /var/vcap/sys/log/monit/$SCRIPT.err.log
+}
+
+function pid_is_running() {
+  declare pid="$1"
+  ps -p "${pid}" >/dev/null 2>&1
+}
+
+# pid_guard
+#
+# @param pidfile
+# @param name [String] an arbitrary name that might show up in STDOUT on errors
+#
+# Run this before attempting to start new processes that may use the same :pidfile:.
+# If an old process is running on the pid found in the :pidfile:, exit 1. Otherwise,
+# remove the stale :pidfile: if it exists.
+#
+function pid_guard() {
+  declare pidfile="$1" name="$2"
+
+  echo "------------ STARTING $(basename "$0") at $(date) --------------" | tee /dev/stderr
+
+  if [ ! -f "${pidfile}" ]; then
+    return 0
+  fi
+
+  local pid
+  pid=$(head -1 "${pidfile}")
+
+  if pid_is_running "${pid}"; then
+    echo "${name} is already running, please stop it first"
+    exit 1
+  fi
+
+  echo "Removing stale pidfile"
+  rm "${pidfile}"
+}
+
+# wait_pid_death
+#
+# @param pid
+# @param timeout
+#
+# Watch a :pid: for :timeout: seconds, waiting for it to die.
+# If it dies before :timeout:, exit 0. If not, exit 1.
+#
+# Note that this should be run in a subshell, so that the current
+# shell does not exit.
+#
+function wait_pid_death() {
+  declare pid="$1" timeout="$2"
+
+  local countdown
+  countdown=$(( timeout * 10 ))
+
+  while true; do
+    if ! pid_is_running "${pid}"; then
+      return 0
+    fi
+
+    if [ ${countdown} -le 0 ]; then
+      return 1
+    fi
+
+    countdown=$(( countdown - 1 ))
+    sleep 0.1
+  done
+}
+
+# kill_and_wait
+#
+# @param pidfile
+# @param timeout [default 25s]
+#
+# For a pid found in :pidfile:, send a `kill -15` TERM, then wait for :timeout: seconds to
+# see if it dies on its own. If not, send it a `kill -9`. If the process does die,
+# exit 0 and remove the :pidfile:. If after all of this, the process does not actually
+# die, exit 1.
+#
+# Note:
+# Monit default timeout for start/stop is 30s
+# Append 'with timeout {n} seconds' to monit start/stop program configs
+#
+function kill_and_wait() {
+  declare pidfile="$1" timeout="${2:-25}" sigkill_on_timeout="${3:-1}"
+
+  if [ ! -f "${pidfile}" ]; then
+    echo "Pidfile ${pidfile} doesn't exist"
+    exit 0
+  fi
+
+  local pid
+  pid=$(head -1 "${pidfile}")
+
+  if [ -z "${pid}" ]; then
+    echo "Unable to get pid from ${pidfile}"
+    exit 1
+  fi
+
+  if ! pid_is_running "${pid}"; then
+    echo "Process ${pid} is not running"
+    rm -f "${pidfile}"
+    exit 0
+  fi
+
+  echo "Killing ${pidfile}: ${pid} "
+  kill "${pid}"
+
+  if ! wait_pid_death "${pid}" "${timeout}"; then
+    if [ "${sigkill_on_timeout}" = "1" ]; then
+      echo "Kill timed out, using kill -9 on ${pid}"
+      kill -9 "${pid}"
+      sleep 0.5
+    fi
+  fi
+
+  if pid_is_running "${pid}"; then
+    echo "Timed Out"
+    exit 1
+  else
+    echo "Stopped"
+    rm -f "${pidfile}"
+  fi
+}
+
+check_nfs_mount() {
+  opts=$1
+  exports=$2
+  mount_point=$3
+
+  if grep -qs $mount_point /proc/mounts; then
+    echo "Found NFS mount $mount_point"
+  else
+    echo "Mounting NFS..."
+    mount $opts $exports $mount_point
+    if [ $? != 0 ]; then
+      echo "Cannot mount NFS from $exports to $mount_point, exiting..."
+      exit 1
+    fi
+  fi
+}
+
+ensure_no_more_logstash() {
+  for java_pid in $(ps -ef | grep java | grep logstash/runner.rb |grep -Po '\-DPID=\K[^ ]+'); do
+    echo "Found leftover Java process - killing($java_pid) if running: `ps -fp $java_pid`"
+    kill -9 $java_pid
+  done
+}


### PR DESCRIPTION
Adds an archiver logstash job that reads off syslog and writes to user-defined outputs with minimal filtering. Our use case is to consume the firehose and write it directly to s3 without any filtering using the s3 output plugin. We used to do this with the ingestor job, but now that filtering has moved from the parsers to the ingestors, we need another method for getting unfiltered logs to s3.

cc @LinuxBozo @cnelson