### PR TITLE
When not using links, the curator fails

### DIFF
--- a/jobs/curator/spec
+++ b/jobs/curator/spec
@@ -21,9 +21,10 @@ consumes:
    optional: true
 
 properties:
-  curator.elasticsearch.host:
+  curator.elasticsearch.hosts:
     description: IP address of elasticsearch host to proxy requests for (eg, 127.0.0.1)
-    default: "127.0.0.1"
+    default: 
+    - "127.0.0.1"
   curator.elasticsearch.port:
     description: Port address of elasticsearch host to proxy requests for (eg, 9200)
     default: 9200


### PR DESCRIPTION
[Because it expect to find a property named `hosts` not `host`](https://github.com/cloudfoundry-community/logsearch-boshrelease/blob/develop/jobs/curator/templates/config/config.yml.erb#L9)