### PR TITLE
Allow multiple non-file parser filters.

### DIFF
--- a/jobs/ingestor_syslog/templates/bin/ingestor_syslog_ctl
+++ b/jobs/ingestor_syslog/templates/bin/ingestor_syslog_ctl
@@ -73,14 +73,16 @@ case $1 in
     cat /var/vcap/packages/logsearch-config/logstash-filters-default.conf >> ${JOB_DIR}/config/logstash.conf
 
     <% if p('logstash_parser.filters').is_a? Array %>
-      # logstash_parser.filters is a list of filter rules
-      <% p('logstash_parser.filters').each do |filter| name, path = filter.first %>
-        cat "<%= path %>" >> ${JOB_DIR}/config/logstash.conf
+      <% p('logstash_parser.filters').each do |filter| %>
+        <% if filter.key? 'path' %>
+          cat "<%= filter['path'] %>" >> ${JOB_DIR}/config/logstash.conf
+        <% elsif !filter.key? 'content' %>
+          <% _, path = filter.first %>
+          cat "<%= path %>" >> ${JOB_DIR}/config/logstash.conf
+        <% end %>
       <% end %>
-    <% elsif p('logstash_parser.filters') != '' %>
-      # logstash_parser.filters is a block of text, which we treat as logstash filter config
-      cat ${JOB_DIR}/config/filters_override.conf >> ${JOB_DIR}/config/logstash.conf
     <% end %>
+    cat ${JOB_DIR}/config/filters_override.conf >> ${JOB_DIR}/config/logstash.conf
 
     cat ${JOB_DIR}/config/filters_post.conf >> ${JOB_DIR}/config/logstash.conf
     <% if p('logstash_parser.enable_json_filter') %>

--- a/jobs/ingestor_syslog/templates/config/filters_override.conf.erb
+++ b/jobs/ingestor_syslog/templates/config/filters_override.conf.erb
@@ -1,1 +1,9 @@
-<%= p('logstash_parser.filters').empty? ? ' ' :  p('logstash_parser.filters')  %>
+<% if p('logstash_parser.filters').is_a? Array %>
+  <% p('logstash_parser.filters').each do |filter| %>
+    <% if filter.key? 'content' %>
+      <%= filter['content'] %>
+    <% end %>
+  <% end %>
+<% elsif p('logstash_parser.filters') != '' %>
+  <%= p('logstash_parser.filters') %>
+<% end %>


### PR DESCRIPTION
As an operator, I want to be able to include both files and inline content in parser filters, like this:

```yaml
logstash_parser:
  filters:
  - path: /path/to/file
  - content: |
    if [@source][component] == "junk" {
      drop{}
    }
```

This patch aims for backwards compatibility, so that users can still use the previous interface:

```yaml
logstash_parser:
  filters:
  - some_name: /path/to/file
```

cc @cnelson @wjwoodson