### PR TITLE
Drop deprecated `flush_size` option.

### DIFF
--- a/jobs/ingestor_syslog/spec
+++ b/jobs/ingestor_syslog/spec
@@ -150,9 +150,6 @@ properties:
   logstash_parser.elasticsearch.data_hosts:
     description: The list of elasticsearch data node IPs
     default: [127.0.0.1]
-  logstash_parser.elasticsearch.flush_size:
-    description: Controls how many logs will be buffered and sent to Elasticsearch for bulk indexing
-    default: 500
   logstash_parser.timecop.reject_greater_than_hours:
     description: "Logs with timestamps greater than this many hours in the future won't be parsed and will get tagged with fail/timecop"
     default: 1

--- a/jobs/ingestor_syslog/templates/config/input_and_output.conf.erb
+++ b/jobs/ingestor_syslog/templates/config/input_and_output.conf.erb
@@ -56,7 +56,6 @@ output {
             <%
               options = {
                 "hosts" => [ p('logstash_parser.elasticsearch.data_hosts').map { |ip| "#{ip}:9200" }.join(',') ],
-                "flush_size" => p('logstash_parser.elasticsearch.flush_size'),
                 "index" => p('logstash_parser.elasticsearch.index'),
                 "document_type" => p('logstash_parser.elasticsearch.index_type'),
                 "manage_template" => false

--- a/src/logsearch-config/spec/logstash-templates/input_and_output/test_default-config.yml
+++ b/src/logsearch-config/spec/logstash-templates/input_and_output/test_default-config.yml
@@ -14,4 +14,3 @@ properties:
       index_type: "%{@type}"
       idle_flush_time: 100
       data_hosts: [127.0.0.1]
-      flush_size: 500

--- a/src/logsearch-config/spec/logstash-templates/input_and_output/test_default-expected.conf
+++ b/src/logsearch-config/spec/logstash-templates/input_and_output/test_default-expected.conf
@@ -14,7 +14,6 @@ input {
 output {
   elasticsearch {
     hosts => ["127.0.0.1:9200"]
-    flush_size => 500
     index => "logs-%{[@metadata][index]}-%{+YYYY.MM.dd}"
     document_type => "%{@type}"
     manage_template => false

--- a/src/logsearch-config/spec/logstash-templates/input_and_output/test_enabled_debug-config.yml
+++ b/src/logsearch-config/spec/logstash-templates/input_and_output/test_enabled_debug-config.yml
@@ -13,4 +13,3 @@ properties:
       index: "logs-%{[@metadata][index]}-%{+YYYY.MM.dd}"
       index_type: "%{@type}"
       data_hosts: [127.0.0.1]
-      flush_size: 500

--- a/src/logsearch-config/spec/logstash-templates/input_and_output/test_enabled_debug-expected.conf
+++ b/src/logsearch-config/spec/logstash-templates/input_and_output/test_enabled_debug-expected.conf
@@ -19,7 +19,6 @@ output {
 
     elasticsearch {
         hosts => ["127.0.0.1:9200"]
-        flush_size => 500
         index => "logs-%{[@metadata][index]}-%{+YYYY.MM.dd}"
         document_type => "%{@type}"
         manage_template => false

--- a/src/logsearch-config/spec/logstash-templates/input_and_output/test_inputs-config.yml
+++ b/src/logsearch-config/spec/logstash-templates/input_and_output/test_inputs-config.yml
@@ -14,4 +14,3 @@ properties:
       index: "logs-%{[@metadata][index]}-%{+YYYY.MM.dd}"
       index_type: "%{@type}"
       data_hosts: [127.0.0.1]
-      flush_size: 500

--- a/src/logsearch-config/spec/logstash-templates/input_and_output/test_inputs-expected.conf
+++ b/src/logsearch-config/spec/logstash-templates/input_and_output/test_inputs-expected.conf
@@ -23,7 +23,6 @@ input {
 output {
     elasticsearch {
         hosts => ["127.0.0.1:9200"]
-        flush_size => 500
         index => "logs-%{[@metadata][index]}-%{+YYYY.MM.dd}"
         document_type => "%{@type}"
         manage_template => false

--- a/src/logsearch-config/spec/logstash-templates/input_and_output/test_outputs-config.yml
+++ b/src/logsearch-config/spec/logstash-templates/input_and_output/test_outputs-config.yml
@@ -13,4 +13,3 @@ properties:
       index: "logs-%{[@metadata][index]}-%{+YYYY.MM.dd}"
       index_type: "%{@type}"
       data_hosts: [127.0.0.1]
-      flush_size: 500

--- a/src/logsearch-config/spec/logstash-templates/input_and_output/test_outputs-expected.conf
+++ b/src/logsearch-config/spec/logstash-templates/input_and_output/test_outputs-expected.conf
@@ -19,7 +19,6 @@ output {
 
     elasticsearch {
         hosts => ["127.0.0.1:9200"]
-        flush_size => 500
         index => "logs-%{[@metadata][index]}-%{+YYYY.MM.dd}"
         document_type => "%{@type}"
         manage_template => false

--- a/src/logsearch-config/spec/logstash-templates/input_and_output/test_outputs_elasticsearch_all_properties-config.yml
+++ b/src/logsearch-config/spec/logstash-templates/input_and_output/test_outputs_elasticsearch_all_properties-config.yml
@@ -15,4 +15,3 @@ properties:
       routing: "%{some_field}"
       idle_flush_time: 100
       data_hosts: [127.0.0.1]
-      flush_size: 500

--- a/src/logsearch-config/spec/logstash-templates/input_and_output/test_outputs_elasticsearch_all_properties-expected.conf
+++ b/src/logsearch-config/spec/logstash-templates/input_and_output/test_outputs_elasticsearch_all_properties-expected.conf
@@ -15,7 +15,6 @@ output {
 
     elasticsearch {
         hosts => ["127.0.0.1:9200"]
-        flush_size => 500
         index => "logs-%{[@metadata][index]}-%{+YYYY.MM.dd}"
         document_type => "%{@type}"
         manage_template => false

--- a/src/logsearch-config/spec/logstash-templates/input_and_output/test_outputs_elasticsearch_required_properties-config.yml
+++ b/src/logsearch-config/spec/logstash-templates/input_and_output/test_outputs_elasticsearch_required_properties-config.yml
@@ -12,4 +12,3 @@ properties:
       index: "logs-%{[@metadata][index]}-%{+YYYY.MM.dd}"
       index_type: "%{@type}"
       data_hosts: [127.0.0.1]
-      flush_size: 500

--- a/src/logsearch-config/spec/logstash-templates/input_and_output/test_outputs_elasticsearch_required_properties-expected.conf
+++ b/src/logsearch-config/spec/logstash-templates/input_and_output/test_outputs_elasticsearch_required_properties-expected.conf
@@ -15,7 +15,6 @@ output {
 
     elasticsearch {
         hosts => ["127.0.0.1:9200"]
-        flush_size => 500
         index => "logs-%{[@metadata][index]}-%{+YYYY.MM.dd}"
         document_type => "%{@type}"
         manage_template => false

--- a/src/logsearch-config/spec/logstash-templates/input_and_output/test_outputs_no_elasticsearch-config.yml
+++ b/src/logsearch-config/spec/logstash-templates/input_and_output/test_outputs_no_elasticsearch-config.yml
@@ -13,4 +13,3 @@ properties:
       index: "logs-%{[@metadata][index]}-%{+YYYY.MM.dd}"
       index_type: "%{@type}"
       data_hosts: [127.0.0.1]
-      flush_size: 500


### PR DESCRIPTION
This option is deprecated and no longer useful, according to the plugin
docs:
https://github.com/logstash-plugins/logstash-output-elasticsearch/blob/master/lib/logstash/outputs/elasticsearch/common_configs.rb#L97