### PR TITLE
Add support of Elasticsearch snapshot and restore feature 

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -8,6 +8,11 @@ bosh -e my-env -d logsearch deploy logsearch-deployment.yml \
   -v cf_admin_password="password" \
   -v uaa_admin_client_secret="secret" \
   -v system_domain="some-domain" \
+  -v aws_access_key="access-key" \
+  -v aws_secret_key="secret-key" \
+  -v aws_region="us-east-1" \
+  -v aws_bucket="some-bucket" \
+  -v snapshots_repository="some-repository" \
   [ -o operations/CUSTOMIZATION1 ] \
   [ -o operations/CUSTOMIZATION2 (etc.) ] 
 ```

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -8,11 +8,6 @@ bosh -e my-env -d logsearch deploy logsearch-deployment.yml \
   -v cf_admin_password="password" \
   -v uaa_admin_client_secret="secret" \
   -v system_domain="some-domain" \
-  -v aws_access_key="access-key" \
-  -v aws_secret_key="secret-key" \
-  -v aws_region="us-east-1" \
-  -v aws_bucket="some-bucket" \
-  -v snapshots_repository="some-repository" \
   [ -o operations/CUSTOMIZATION1 ] \
   [ -o operations/CUSTOMIZATION2 (etc.) ] 
 ```

--- a/deployment/operations/s3-snapshots.yml
+++ b/deployment/operations/s3-snapshots.yml
@@ -1,0 +1,34 @@
+---
+- type: replace
+  path: /instance_groups/name=elasticsearch_master/jobs/name=elasticsearch/properties/elasticsearch/cloud?
+  value:
+    repository: "((snapshots_repository))"
+    aws:
+      access_key: "((aws_access_key))"
+      secret_key: "((aws_secret_key))"
+      region: "((aws_region))"
+      bucket: "((aws_bucket))"
+- type: replace
+  path: /instance_groups/name=elasticsearch_data/jobs/name=elasticsearch/properties/elasticsearch/cloud?
+  value:
+    repository: "((snapshots_repository))"
+    aws:
+      access_key: "((aws_access_key))"
+      secret_key: "((aws_secret_key))"
+      region: "((aws_region))"
+      bucket: "((aws_bucket))"
+- type: replace
+  path: /instance_groups/name=maintenance/jobs/name=curator/properties?
+  value:
+    curator:
+      actions:
+      - action: snapshot
+        description: >-
+          Create snapshots for all indicies
+        options:
+          repository: "((snapshots_repository))"
+          wait_for_completion: True
+        filters:
+        - filtertype: pattern
+          kind: prefix
+          value: logs-

--- a/deployment/operations/snapshots-s3.yml
+++ b/deployment/operations/snapshots-s3.yml
@@ -1,0 +1,27 @@
+---
+- type: replace
+  path: /instance_groups/name=elasticsearch_master/jobs/name=elasticsearch/properties/elasticsearch/snapshots?
+  value:
+    repository: "((snapshots_repository))"
+- type: replace
+  path: /instance_groups/name=elasticsearch_master/jobs/name=elasticsearch/properties/elasticsearch/cloud?
+  value:
+    aws:
+      access_key: "((aws_access_key))"
+      secret_key: "((aws_secret_key))"
+      bucket: "((aws_bucket))"
+- type: replace
+  path: /instance_groups/name=elasticsearch_data/jobs/name=elasticsearch/properties/elasticsearch/snapshots?
+  value:
+    repository: "((snapshots_repository))"
+- type: replace
+  path: /instance_groups/name=elasticsearch_data/jobs/name=elasticsearch/properties/elasticsearch/cloud?
+  value:
+    aws:
+      access_key: "((aws_access_key))"
+      secret_key: "((aws_secret_key))"
+      bucket: "((aws_bucket))"
+- type: replace
+  path: /instance_groups/name=maintenance/jobs/name=curator/properties/elasticsearch?/snapshots?
+  value:
+    repository: "((snapshots_repository))"

--- a/jobs/curator/spec
+++ b/jobs/curator/spec
@@ -21,9 +21,12 @@ consumes:
    optional: true
 
 properties:
+  elasticsearch.cloud.repository:
+    description: Repository name for automatic snapshots
+
   curator.elasticsearch.hosts:
     description: IP address of elasticsearch host to proxy requests for (eg, 127.0.0.1)
-    default: 
+    default:
     - "127.0.0.1"
   curator.elasticsearch.port:
     description: Port address of elasticsearch host to proxy requests for (eg, 9200)

--- a/jobs/curator/spec
+++ b/jobs/curator/spec
@@ -40,6 +40,9 @@ properties:
   curator.loglevel:
     description: Set the minimum acceptable log severity to display.
     default: INFO
+  curator.cron_schedule:
+    description: Schedule to trigger Curator, using normal cron format
+    default: 0 0 * * *
   curator.logformat:
     description: This should default, json, logstash.
     default: default

--- a/jobs/curator/spec
+++ b/jobs/curator/spec
@@ -21,7 +21,7 @@ consumes:
    optional: true
 
 properties:
-  elasticsearch.cloud.repository:
+  elasticsearch.snapshots.repository:
     description: Repository name for automatic snapshots
 
   curator.elasticsearch.hosts:

--- a/jobs/curator/templates/config/actions.yml.erb
+++ b/jobs/curator/templates/config/actions.yml.erb
@@ -1,6 +1,6 @@
 ---
 actions:
-  <% if_p('elasticsearch.cloud.repository') do |repo| %>
+  <% if_p('elasticsearch.snapshots.repository') do |repo| %>
   1:
     action: snapshot
     description: >-

--- a/jobs/curator/templates/config/actions.yml.erb
+++ b/jobs/curator/templates/config/actions.yml.erb
@@ -1,6 +1,25 @@
 ---
 actions:
+  <% if_p('elasticsearch.cloud.repository') do |repo| %>
   1:
+    action: snapshot
+    description: >-
+      Create snapshot for all indicies
+    options:
+      repository: <%= repo %>
+      wait_for_completion: True
+      ignore_empty_list: True
+    filters:
+    - filtertype: pattern
+      kind: prefix
+      value: logs-
+    - filtertype: age
+      source: creation_date
+      direction: older
+      unit: <%= p('curator.purge_logs.unit') %>
+      unit_count: <%= p('curator.purge_logs.retention_period') %>
+  <% end %>
+  2:
     action: delete_indices
     description: >-
       Delete indices older than <%= p('curator.purge_logs.retention_period') %> <%= p('curator.purge_logs.unit') %> (based on index name), for logs-
@@ -19,5 +38,5 @@ actions:
       unit: <%= p('curator.purge_logs.unit') %>
       unit_count: <%= p('curator.purge_logs.retention_period') %>
 <% p("curator.actions", []).each_with_index do | action, index | %>
-  <%= index + 2 %>:<%= action.to_yaml.gsub("---", "").gsub("\n", "\n    ") %>
+  <%= index + 3 %>:<%= action.to_yaml.gsub("---", "").gsub("\n", "\n    ") %>
 <% end %>

--- a/jobs/curator/templates/config/purge_logs.cron
+++ b/jobs/curator/templates/config/purge_logs.cron
@@ -1,1 +1,1 @@
-30 2 * * * /var/vcap/jobs/curator/bin/run >>/var/vcap/sys/log/curator/curator.log 2>&1
+<%= p('curator.cron_schedule') %> /var/vcap/jobs/curator/bin/run >>/var/vcap/sys/log/curator/curator.log 2>&1

--- a/jobs/curator/templates/config/purge_logs.cron
+++ b/jobs/curator/templates/config/purge_logs.cron
@@ -1,1 +1,1 @@
-*/59 * * * * /var/vcap/jobs/curator/bin/run >>/var/vcap/sys/log/curator/curator.log 2>&1
+30 2 * * * /var/vcap/jobs/curator/bin/run >>/var/vcap/sys/log/curator/curator.log 2>&1

--- a/jobs/elasticsearch/spec
+++ b/jobs/elasticsearch/spec
@@ -116,3 +116,7 @@ properties:
   elasticsearch.cloud.aws.read_timeout:
     description: The amount of time to wait for data to be transferred over an established, open connection before the connection is timed out
     default: 50s
+  elasticsearch.cloud.aws.bucket:
+    description: Bucket name on S3 where to keep snapshots
+  elasticsearch.cloud.repository:
+    description: Repository name for automatic snapshots

--- a/jobs/elasticsearch/spec
+++ b/jobs/elasticsearch/spec
@@ -103,3 +103,16 @@ properties:
   elasticsearch.health.disable_post_start:
     description: Allow node to run post-start script? (true / false)
     default: false
+
+  elasticsearch.cloud.aws.access_key:
+    description: Access key ID for AWS account
+  elasticsearch.cloud.aws.secret_key:
+    description: Secret access key for AWS account
+  elasticsearch.cloud.aws.region:
+    description: Specify the AWS region to use
+  elasticsearch.cloud.aws.protocol:
+    description: Protocol to use for all API calls to AWS endpoints
+    default: "https"
+  elasticsearch.cloud.aws.read_timeout:
+    description: The amount of time to wait for data to be transferred over an established, open connection before the connection is timed out
+    default: 50s

--- a/jobs/elasticsearch/spec
+++ b/jobs/elasticsearch/spec
@@ -48,6 +48,13 @@ properties:
     default: []
   elasticsearch.heap_size:
     description: sets jvm heap sized
+  elasticsearch.path_repo:
+    description: |
+      Shared file system to store snapshots.
+      In order to register the shared file system repository it is
+      necessary to mount the same shared filesystem to the same location
+      on all master and data nodes.
+    default: ''
   elasticsearch.node.allow_master:
     description: Allow node to become master? (true / false)
     default: false
@@ -118,6 +125,7 @@ properties:
     default: 50s
   elasticsearch.cloud.aws.bucket:
     description: Bucket name on S3 where to keep snapshots
-  elasticsearch.cloud.repository:
+    default: ''
+  elasticsearch.snapshots.repository:
     description: Repository name for automatic snapshots
     default: ''

--- a/jobs/elasticsearch/spec
+++ b/jobs/elasticsearch/spec
@@ -120,3 +120,4 @@ properties:
     description: Bucket name on S3 where to keep snapshots
   elasticsearch.cloud.repository:
     description: Repository name for automatic snapshots
+    default: ''

--- a/jobs/elasticsearch/spec
+++ b/jobs/elasticsearch/spec
@@ -7,6 +7,7 @@ packages:
 
 templates:
   bin/drain.erb: bin/drain
+  bin/post-deploy.erb: bin/post-deploy
   bin/post-start.erb: bin/post-start
   bin/elasticsearch_ctl: bin/elasticsearch_ctl
   bin/monit_debugger: bin/monit_debugger

--- a/jobs/elasticsearch/templates/bin/drain.erb
+++ b/jobs/elasticsearch/templates/bin/drain.erb
@@ -11,6 +11,14 @@ curl -s -X PUT localhost:9200/_all/_settings \
 
 <% end %>
 
+<% if p('elasticsearch.cloud.aws.bucket') != '' and p('elasticsearch.node.allow_master') and spec.bootstrap %>
+curl -X DELETE -s localhost:9200/_snapshot/<%= p('elasticsearch.snapshots.repository') %>
+<% end %>
+
+<% if p('elasticsearch.path_repo') != '' and p('elasticsearch.node.allow_master') and spec.bootstrap %>
+curl -X PUT -s localhost:9200/_snapshot/<%= p('elasticsearch.snapshots.repository') %>
+<% end %>
+
 return_code=$?
 echo 0
 exit ${return_code}

--- a/jobs/elasticsearch/templates/bin/drain.erb
+++ b/jobs/elasticsearch/templates/bin/drain.erb
@@ -12,11 +12,11 @@ curl -s -X PUT localhost:9200/_all/_settings \
 <% end %>
 
 <% if p('elasticsearch.cloud.aws.bucket') != '' and p('elasticsearch.node.allow_master') and spec.bootstrap %>
-curl -X DELETE -s localhost:9200/_snapshot/<%= p('elasticsearch.snapshots.repository') %>
+curl -X DELETE -s localhost:9200/_snapshot/<%= p('elasticsearch.snapshots.repository') %> > /dev/null
 <% end %>
 
 <% if p('elasticsearch.path_repo') != '' and p('elasticsearch.node.allow_master') and spec.bootstrap %>
-curl -X PUT -s localhost:9200/_snapshot/<%= p('elasticsearch.snapshots.repository') %>
+curl -X DELETE -s localhost:9200/_snapshot/<%= p('elasticsearch.snapshots.repository') %> > /dev/null
 <% end %>
 
 return_code=$?

--- a/jobs/elasticsearch/templates/bin/elasticsearch_ctl
+++ b/jobs/elasticsearch/templates/bin/elasticsearch_ctl
@@ -40,6 +40,9 @@ case $1 in
 
     # install plugins
     rm -rf /var/vcap/packages/elasticsearch/plugins/*
+    <% if_p('elasticsearch.cloud.aws.access_key', 'elasticsearch.cloud.aws.secret_key') do %>
+      /var/vcap/packages/elasticsearch/bin/elasticsearch-plugin install repository-s3
+    <% end %>
     <% p("elasticsearch.plugins").each do |plugin| name, path = plugin.first %>
       <% if path.start_with? '/var/vcap' %>
         /var/vcap/packages/elasticsearch/bin/elasticsearch-plugin install "file://<%= path %>"

--- a/jobs/elasticsearch/templates/bin/elasticsearch_ctl
+++ b/jobs/elasticsearch/templates/bin/elasticsearch_ctl
@@ -41,7 +41,7 @@ case $1 in
     # install plugins
     rm -rf /var/vcap/packages/elasticsearch/plugins/*
     <% if_p('elasticsearch.cloud.aws.access_key', 'elasticsearch.cloud.aws.secret_key') do %>
-      /var/vcap/packages/elasticsearch/bin/elasticsearch-plugin install repository-s3
+      /var/vcap/packages/elasticsearch/bin/elasticsearch-plugin install -b repository-s3
     <% end %>
     <% p("elasticsearch.plugins").each do |plugin| name, path = plugin.first %>
       <% if path.start_with? '/var/vcap' %>

--- a/jobs/elasticsearch/templates/bin/post-deploy.erb
+++ b/jobs/elasticsearch/templates/bin/post-deploy.erb
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+
+<% if p('elasticsearch.cloud.aws.bucket') != '' and p('elasticsearch.node.allow_master') and spec.bootstrap %>
+curl -X PUT -s localhost:9200/_snapshot/<%= p('elasticsearch.snapshots.repository') %> \
+  -d '{"type": "s3", "settings": {"bucket": "<%= p('elasticsearch.cloud.aws.bucket') %>"}}'
+<% end %>
+
+<% if p('elasticsearch.path_repo') != '' and p('elasticsearch.node.allow_master') and spec.bootstrap %>
+curl -X PUT -s localhost:9200/_snapshot/<%= p('elasticsearch.snapshots.repository') %> \
+  -d '{"type": "fs", "settings": {"location": "<%= p('elasticsearch.path_repo') %>/<%= p('elasticsearch.snapshots.repository') %>", "compress": true}}'
+<% end %>

--- a/jobs/elasticsearch/templates/bin/post-start.erb
+++ b/jobs/elasticsearch/templates/bin/post-start.erb
@@ -56,6 +56,13 @@ curl -X PUT -s localhost:9200/_all/_settings \
   -d '{"settings": {"index.unassigned.node_left.delayed_timeout": "<%= p("elasticsearch.recovery.delay_allocation") %>"}}'
 <% end %>
 
+<% if_p('elasticsearch.cloud.repository') do %>
+  REP=`curl -s localhost:9200/_snapshot/<%= p("elasticsearch.cloud.repository") %> | grep <%= p("elasticsearch.cloud.aws.bucket") %> | wc -l`
+  if [ $REP == 0 ]; then
+    curl -XPUT localhost:9200/_snapshot/<%= p("elasticsearch.cloud.repository") %> -d '{"type": "s3", "settings": {"bucket": "<%= p("elasticsearch.cloud.aws.bucket") %>"}}'
+  fi
+<% end %>
+
 <% else %>
 
 echo "Disable post start script property is set to <%= p("elasticsearch.health.disable_post_start") %>. Skipping post-start..."

--- a/jobs/elasticsearch/templates/bin/post-start.erb
+++ b/jobs/elasticsearch/templates/bin/post-start.erb
@@ -56,9 +56,14 @@ curl -X PUT -s localhost:9200/_all/_settings \
   -d '{"settings": {"index.unassigned.node_left.delayed_timeout": "<%= p("elasticsearch.recovery.delay_allocation") %>"}}'
 <% end %>
 
-<% if p('elasticsearch.cloud.repository') != '' and p('elasticsearch.node.allow_master') and spec.bootstrap %>
-curl -X PUT -s localhost:9200/_snapshot/<%= p('elasticsearch.cloud.repository') %> \
+<% if p('elasticsearch.cloud.aws.bucket') != '' and p('elasticsearch.node.allow_master') and spec.bootstrap %>
+curl -X PUT -s localhost:9200/_snapshot/<%= p('elasticsearch.snapshots.repository') %> \
   -d '{"type": "s3", "settings": {"bucket": "<%= p('elasticsearch.cloud.aws.bucket') %>"}}'
+<% end %>
+
+<% if p('elasticsearch.path_repo') != '' and p('elasticsearch.node.allow_master') and spec.bootstrap %>
+curl -X PUT -s localhost:9200/_snapshot/<%= p('elasticsearch.snapshots.repository') %> \
+  -d '{"type": "fs", "settings": {"location": "<%= p('elasticsearch.path_repo') %>/<%= p('elasticsearch.snapshots.repository') %>", "compress": true}}'
 <% end %>
 
 <% else %>

--- a/jobs/elasticsearch/templates/bin/post-start.erb
+++ b/jobs/elasticsearch/templates/bin/post-start.erb
@@ -56,11 +56,9 @@ curl -X PUT -s localhost:9200/_all/_settings \
   -d '{"settings": {"index.unassigned.node_left.delayed_timeout": "<%= p("elasticsearch.recovery.delay_allocation") %>"}}'
 <% end %>
 
-<% if_p('elasticsearch.cloud.repository') do %>
-  REP=`curl -s localhost:9200/_snapshot/<%= p("elasticsearch.cloud.repository") %> | grep <%= p("elasticsearch.cloud.aws.bucket") %> | wc -l`
-  if [ $REP == 0 ]; then
-    curl -XPUT localhost:9200/_snapshot/<%= p("elasticsearch.cloud.repository") %> -d '{"type": "s3", "settings": {"bucket": "<%= p("elasticsearch.cloud.aws.bucket") %>"}}'
-  fi
+<% if p('elasticsearch.cloud.repository') != '' and p('elasticsearch.node.allow_master') and spec.bootstrap %>
+curl -X PUT -s localhost:9200/_snapshot/<%= p('elasticsearch.cloud.repository') %> \
+  -d '{"type": "s3", "settings": {"bucket": "<%= p('elasticsearch.cloud.aws.bucket') %>"}}'
 <% end %>
 
 <% else %>

--- a/jobs/elasticsearch/templates/config/config.yml.erb
+++ b/jobs/elasticsearch/templates/config/config.yml.erb
@@ -53,5 +53,14 @@ discovery.zen.minimum_master_nodes: <%= minimum_master_nodes %>
 %>
 discovery.zen.ping.unicast.hosts: "<%= master_hosts %>"
 
-<% if_p('elasticsearch.config_options') do | v | %><%= v %><% end %>
+<% if_p('elasticsearch.cloud.aws.access_key', 'elasticsearch.cloud.aws.secret_key') do %>
+cloud:
+  aws:
+    protocol: <%= p('elasticsearch.cloud.aws.protocol') %>
+    read_timeout: <%= p('elasticsearch.cloud.aws.read_timeout') %>
+    access_key: <%= p('elasticsearch.cloud.aws.access_key') %>
+    secret_key: <%= p('elasticsearch.cloud.aws.secret_key') %>
+    <% if_p('elasticsearch.cloud.aws.region') do |region| %>region: <%= region %><% end %>
+<% end %>
 
+<% if_p('elasticsearch.config_options') do | v | %><%= v %><% end %>

--- a/jobs/elasticsearch/templates/config/config.yml.erb
+++ b/jobs/elasticsearch/templates/config/config.yml.erb
@@ -4,6 +4,9 @@ path.conf: "/var/vcap/jobs/elasticsearch/config"
 path.logs: "/var/vcap/sys/log/elasticsearch"
 path.data: "/var/vcap/store/elasticsearch"
 path.scripts: "/var/vcap/data/elasticsearch/plugin-scripts"
+<% if p('elasticsearch.path_repo') != '' %>
+path.repo: ["<%= p('elasticsearch.path_repo') %>"]
+<% end %>
 
 <%
   cluster_name = nil


### PR DESCRIPTION
Support shared file system and aws s3 repos. Require [post-deploy](https://bosh.io/docs/post-deploy.html) scripts to be enabled in bosh director.