### PR TITLE
Fix Ruby syntax errors in "filters_post"

### DIFF
--- a/jobs/ingestor_syslog/templates/config/filters_post.conf.erb
+++ b/jobs/ingestor_syslog/templates/config/filters_post.conf.erb
@@ -3,12 +3,12 @@
         ruby {
             code => "
                 n = Time.now
-                event.set('@parser[duration]', (1000 * (n - Time.parse(event.get('@parser[timestamp]')))).to_i
-                event.set('@timer[ingested_to_parsed]', (1000 * (n - Time.parse(event.get('@ingestor[timestamp]')))).to_i if event.get('@ingestor[timestamp]'))
+                event.set('@parser[duration]', (1000 * (n - Time.parse(event.get('@parser[timestamp]')))).to_i)
+                event.set('@timer[ingested_to_parsed]', (1000 * (n - Time.parse(event.get('@ingestor[timestamp]')))).to_i) if event.get('@ingestor[timestamp]')
                 timestamp = event.get('@timestamp')
                 if timestamp.instance_of? Time
                     event.set('@timer[emit_to_ingested]', (1000 * (Time.parse(event.get('@ingestor[timestamp]')) - timestamp)).to_i) if event.get('@ingestor[timestamp]')
-                    event.set('@timer[emit_to_parsed]', (1000 * (n - timestamp)).to_i
+                    event.set('@timer[emit_to_parsed]', (1000 * (n - timestamp)).to_i)
                 end
             "
         }


### PR DESCRIPTION
Hi, we were encountering syntax errors in Ruby which cause the pipeline to crash and restart in a loop, if this section is present in your ingestor config. Seems to be due to some missing brackets. Thanks!