### PR TITLE
Fix ls-router job name

### DIFF
--- a/src/logsearch-config/spec/logstash-filters/snippets/haproxy_spec.rb
+++ b/src/logsearch-config/spec/logstash-filters/snippets/haproxy_spec.rb
@@ -27,7 +27,7 @@ describe "Rules for parsing haproxy messages" do
         end
 
         it "adds @source.job" do
-          expect(parsed_result.get("@source")["job"]).to eq "router"
+          expect(parsed_result.get("@source")["job"]).to eq "ls-router"
         end
       end
 
@@ -45,7 +45,7 @@ describe "Rules for parsing haproxy messages" do
         end
 
         it "adds @source.job" do
-          expect(parsed_result.get("@source")["job"]).to eq "router"
+          expect(parsed_result.get("@source")["job"]).to eq "ls-router"
         end
       end
     end

--- a/src/logsearch-config/src/logstash-filters/snippets/haproxy.conf
+++ b/src/logsearch-config/src/logstash-filters/snippets/haproxy.conf
@@ -25,6 +25,6 @@ if [syslog_program] == "ls-router" {
   }
 
   mutate {
-    add_field => [ "[@source][job]", "router" ]
+    add_field => [ "[@source][job]", "ls-router" ]
   }
 }


### PR DESCRIPTION
"router" is not recognized as a valid job belonging to logsearch and thus haproxy logs are dropped