### PR TITLE
Add an optional watchdog timer to Logstash

### DIFF
--- a/jobs/archiver_syslog/monit
+++ b/jobs/archiver_syslog/monit
@@ -3,3 +3,11 @@ check process archiver_syslog
   start program "/var/vcap/jobs/archiver_syslog/bin/monit_debugger archiver_syslog_ctl '/var/vcap/jobs/archiver_syslog/bin/archiver_syslog_ctl start'"  with timeout 120 seconds
   stop program "/var/vcap/jobs/archiver_syslog/bin/monit_debugger archiver_syslog_ctl '/var/vcap/jobs/archiver_syslog/bin/archiver_syslog_ctl stop'"
   group vcap
+
+<% if p("logstash_ingestor.watchdog.enable") %>
+check process archiver_syslog_watchdog
+  with pidfile /var/vcap/sys/run/archiver_syslog/archiver_syslog_watchdog.pid
+  start program "/var/vcap/jobs/archiver_syslog/bin/archiver_syslog_watchdog_ctl start"
+  stop program "/var/vcap/jobs/archiver_syslog/bin/archiver_syslog_watchdog_ctl stop"
+  group vcap
+<% end %>

--- a/jobs/archiver_syslog/spec
+++ b/jobs/archiver_syslog/spec
@@ -5,9 +5,12 @@ packages:
 - logstash
 - logsearch-config
 - java8
+- watchdog
 
 templates:
   bin/archiver_syslog_ctl: bin/archiver_syslog_ctl
+  bin/archiver_syslog_watchdog_ctl: bin/archiver_syslog_watchdog_ctl
+  bin/crash_archiver_syslog: bin/crash_archiver_syslog
   bin/monit_debugger: bin/monit_debugger
   config/input_and_output.conf.erb: config/input_and_output.conf
   config/syslog_tls.crt.erb: config/syslog_tls.crt
@@ -103,3 +106,10 @@ properties:
   logstash_ingestor.outputs:
     description: A list of output plugins, with a hash of options for each of them.
     default: []
+
+  logstash_ingestor.watchdog.enable:
+    description: Enable Logstash watchdog timer
+    default: false
+  logstash_ingestor.watchdog.interval:
+    description: Logstash watchdog timer interval in seconds
+    default: 5

--- a/jobs/archiver_syslog/templates/bin/archiver_syslog_ctl
+++ b/jobs/archiver_syslog/templates/bin/archiver_syslog_ctl
@@ -1,4 +1,9 @@
 #!/bin/bash
+<%
+  if p("logstash_ingestor.watchdog.enable")
+    p("logstash.plugins") << {"name" => "logstash-output-exec", "version" => "3.1.2"}
+  end
+%>
 
 set -e # exit immediately if a simple command exits with a non-zero status
 set -u # report the usage of uninitialized variables

--- a/jobs/archiver_syslog/templates/bin/archiver_syslog_watchdog_ctl
+++ b/jobs/archiver_syslog/templates/bin/archiver_syslog_watchdog_ctl
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+set -eu
+
+JOB_NAME=archiver_syslog_watchdog
+JOB_DIR="/var/vcap/jobs/archiver_syslog"
+LOG_DIR="/var/vcap/sys/log/archiver_syslog"
+PID_FILE="/var/vcap/sys/run/archiver_syslog/${JOB_NAME}.pid"
+
+exec 1>> "/var/vcap/sys/log/monit/${JOB_NAME}.log"
+exec 2>> "/var/vcap/sys/log/monit/${JOB_NAME}.err.log"
+source /var/vcap/jobs/archiver_syslog/helpers/ctl_utils.sh
+
+case $1 in
+
+  start)
+    pid_guard "${PID_FILE}" "${JOB_NAME}"
+    echo $$ > "${PID_FILE}"
+
+    STARTUP_TIME_SECS=300 exec /var/vcap/packages/watchdog/bin/watchdog \
+      archiver_syslog \
+      <%= 3 * p("logstash_ingestor.watchdog.interval") %> \
+      "${JOB_DIR}/bin/crash_archiver_syslog" \
+         >>"${LOG_DIR}/${JOB_NAME}.stdout.log" \
+         2>>"${LOG_DIR}/${JOB_NAME}.stderr.log"
+  ;;
+
+  stop)
+    kill_and_wait "${PID_FILE}"
+    ensure_no_more_logstash
+  ;;
+
+  *)
+    echo "Usage: archiver_syslog_watchdog_ctl {start|stop}"
+  ;;
+esac

--- a/jobs/archiver_syslog/templates/bin/crash_archiver_syslog
+++ b/jobs/archiver_syslog/templates/bin/crash_archiver_syslog
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+set -eu
+
+PID="$(cat /var/vcap/sys/run/ingestor_syslog/ingestor_syslog.pid)"
+
+# SIGQUIT triggers a Java application to dump debugging information and a stack trace of all threads
+# (It doesn't quit the application.)
+kill -QUIT "${PID}"
+sleep 5
+
+/var/vcap/jobs/ingestor_syslog/bin/ingestor_syslog_ctl stop

--- a/jobs/archiver_syslog/templates/config/input_and_output.conf.erb
+++ b/jobs/archiver_syslog/templates/config/input_and_output.conf.erb
@@ -33,6 +33,15 @@ input {
     port => "<%= port %>"
   }
   <% end %>
+
+  <% if p("logstash_ingestor.watchdog.enable") %>
+  heartbeat {
+    id => "watchdog_heartbeat"
+    type => "heartbeat"
+    message => "heartbeat"
+    interval => <%= p("logstash_ingestor.watchdog.interval") %>
+  }
+  <% end %>
 }
 
 filter {
@@ -44,17 +53,27 @@ filter {
 }
 
 output {
-    <% if p("logstash_ingestor.debug") %>
-        stdout {
-            codec => "json"
-        }
-    <% end %>
+  <% if p("logstash_ingestor.debug") %>
+  stdout {
+    codec => "json"
+  }
+  <% end %>
 
-    <% p('logstash_ingestor.outputs').each do | output | %>
-        <%= output['plugin'] %> {
-        <% output['options'].each do | k, v | %>
-          <%= k %> => <%= v.inspect %>
-        <% end %>
-        }
+  <% if p("logstash_ingestor.watchdog.enable") %>
+  if [@type] == "heartbeat" {
+    exec {
+      command => "touch /var/vcap/sys/run/ingestor_syslog/ingestor_syslog.watchdog"
+    }
+  }
+  <% end %>
+
+  if [@type] != "heartbeat" {
+  <% p('logstash_ingestor.outputs').each do | output | %>
+    <%= output['plugin'] %> {
+      <% output['options'].each do | k, v | %>
+        <%= k %> => <%= v.inspect %>
+      <% end %>
+    }
     <% end %>
+  }
 }

--- a/jobs/ingestor_syslog/monit
+++ b/jobs/ingestor_syslog/monit
@@ -3,3 +3,11 @@ check process ingestor_syslog
   start program "/var/vcap/jobs/ingestor_syslog/bin/monit_debugger ingestor_syslog_ctl '/var/vcap/jobs/ingestor_syslog/bin/ingestor_syslog_ctl start'"  with timeout 120 seconds
   stop program "/var/vcap/jobs/ingestor_syslog/bin/monit_debugger ingestor_syslog_ctl '/var/vcap/jobs/ingestor_syslog/bin/ingestor_syslog_ctl stop'"
   group vcap
+
+<% if p("logstash_ingestor.watchdog.enable") %>
+check process ingestor_syslog_watchdog
+  with pidfile /var/vcap/sys/run/ingestor_syslog/ingestor_syslog_watchdog.pid
+  start program "/var/vcap/jobs/ingestor_syslog/bin/ingestor_syslog_watchdog_ctl start"
+  stop program "/var/vcap/jobs/ingestor_syslog/bin/ingestor_syslog_watchdog_ctl stop"
+  group vcap
+<% end %>

--- a/jobs/ingestor_syslog/spec
+++ b/jobs/ingestor_syslog/spec
@@ -5,9 +5,12 @@ packages:
 - logstash
 - logsearch-config
 - java8
+- watchdog
 
 templates:
   bin/ingestor_syslog_ctl: bin/ingestor_syslog_ctl
+  bin/ingestor_syslog_watchdog_ctl: bin/ingestor_syslog_watchdog_ctl
+  bin/crash_ingestor_syslog: bin/crash_ingestor_syslog
   bin/monit_debugger: bin/monit_debugger
   config/input_and_output.conf.erb: config/input_and_output.conf
   config/filters_pre.conf.erb: config/filters_pre.conf
@@ -97,6 +100,13 @@ properties:
   logstash_ingestor.relp.port:
     description: Port to listen for RELP messages
     default: 2514
+
+  logstash_ingestor.watchdog.enable:
+    description: Enable Logstash watchdog timer
+    default: false
+  logstash_ingestor.watchdog.interval:
+    description: Logstash watchdog timer interval in seconds
+    default: 5
 
   logstash_parser.debug:
     description: Debug level logging

--- a/jobs/ingestor_syslog/templates/bin/crash_ingestor_syslog
+++ b/jobs/ingestor_syslog/templates/bin/crash_ingestor_syslog
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+set -eu
+
+PID="$(cat /var/vcap/sys/run/ingestor_syslog/ingestor_syslog.pid)"
+
+# SIGQUIT triggers a Java application to dump debugging information and a stack trace of all threads
+# (It doesn't quit the application.)
+kill -QUIT "${PID}"
+sleep 5
+
+/var/vcap/jobs/ingestor_syslog/bin/ingestor_syslog_ctl stop

--- a/jobs/ingestor_syslog/templates/bin/ingestor_syslog_ctl
+++ b/jobs/ingestor_syslog/templates/bin/ingestor_syslog_ctl
@@ -1,4 +1,9 @@
 #!/bin/bash
+<%
+  if p("logstash_ingestor.watchdog.enable")
+    p("logstash.plugins") << {"name" => "logstash-output-exec", "version" => "3.1.2"}
+  end
+%>
 
 set -e # exit immediately if a simple command exits with a non-zero status
 set -u # report the usage of uninitialized variables

--- a/jobs/ingestor_syslog/templates/bin/ingestor_syslog_watchdog_ctl
+++ b/jobs/ingestor_syslog/templates/bin/ingestor_syslog_watchdog_ctl
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+set -eu
+
+JOB_NAME=ingestor_syslog_watchdog
+JOB_DIR="/var/vcap/jobs/ingestor_syslog"
+LOG_DIR="/var/vcap/sys/log/ingestor_syslog"
+PID_FILE="/var/vcap/sys/run/ingestor_syslog/${JOB_NAME}.pid"
+
+exec 1>> "/var/vcap/sys/log/monit/${JOB_NAME}.log"
+exec 2>> "/var/vcap/sys/log/monit/${JOB_NAME}.err.log"
+source /var/vcap/jobs/ingestor_syslog/helpers/ctl_utils.sh
+
+case $1 in
+
+  start)
+    pid_guard "${PID_FILE}" "${JOB_NAME}"
+    echo $$ > "${PID_FILE}"
+
+    STARTUP_TIME_SECS=300 exec /var/vcap/packages/watchdog/bin/watchdog \
+      ingestor_syslog \
+      <%= 3 * p("logstash_ingestor.watchdog.interval") %> \
+      "${JOB_DIR}/bin/crash_ingestor_syslog" \
+         >>"${LOG_DIR}/${JOB_NAME}.stdout.log" \
+         2>>"${LOG_DIR}/${JOB_NAME}.stderr.log"
+  ;;
+
+  stop)
+    kill_and_wait "${PID_FILE}"
+    ensure_no_more_logstash
+  ;;
+
+  *)
+    echo "Usage: ingestor_syslog_watchdog_ctl {start|stop}"
+  ;;
+esac

--- a/jobs/ingestor_syslog/templates/config/input_and_output.conf.erb
+++ b/jobs/ingestor_syslog/templates/config/input_and_output.conf.erb
@@ -41,40 +41,59 @@ input {
         <% end %>
       }
   <% end %>
+
+  <% if p("logstash_ingestor.watchdog.enable") %>
+  heartbeat {
+    id => "watchdog_heartbeat"
+    type => "heartbeat"
+    message => "heartbeat"
+    interval => <%= p("logstash_ingestor.watchdog.interval") %>
+  }
+  <% end %>
 }
 
 output {
-    <% if p("logstash_parser.debug") %>
-        stdout {
-            codec => "json"
-        }
-    <% end %>
+  <% if p("logstash_parser.debug") %>
+    stdout {
+      codec => "json"
+    }
+  <% end %>
 
-    <% p('logstash_parser.outputs').each do | output | %>
-        <%= output['plugin'] %> {
-        <% if 'elasticsearch' == output['plugin'] %>
-            <%
-              options = {
-                "hosts" => [ p('logstash_parser.elasticsearch.data_hosts').map { |ip| "#{ip}:9200" }.join(',') ],
-                "index" => p('logstash_parser.elasticsearch.index'),
-                "document_type" => p('logstash_parser.elasticsearch.index_type'),
-                "manage_template" => false
-              }
-              if p('logstash_parser.elasticsearch.idle_flush_time', nil)
-                options['idle_flush_time'] = p('logstash_parser.elasticsearch.idle_flush_time')
-              end
-              if p('logstash_parser.elasticsearch.document_id', nil)
-                options['document_id'] = p('logstash_parser.elasticsearch.document_id')
-              end
-              if p('logstash_parser.elasticsearch.routing', nil)
-                options['routing'] = p('logstash_parser.elasticsearch.routing')
-              end
-              output['options'] = options.merge(output['options'])
-            %>
-        <% end %>
-        <% output['options'].each do | k, v | %>
-          <%= k %> => <%= v.inspect %>
-        <% end %>
-        }
-    <% end %>
+  <% if p("logstash_ingestor.watchdog.enable") %>
+  if [@type] == "heartbeat" {
+    exec {
+      command => "touch /var/vcap/sys/run/ingestor_syslog/ingestor_syslog.watchdog"
+    }
+  }
+  <% end %>
+
+  if [@type] != "heartbeat" {
+  <% p('logstash_parser.outputs').each do | output | %>
+      <%= output['plugin'] %> {
+      <% if 'elasticsearch' == output['plugin'] %>
+          <%
+            options = {
+              "hosts" => [ p('logstash_parser.elasticsearch.data_hosts').map { |ip| "#{ip}:9200" }.join(',') ],
+              "index" => p('logstash_parser.elasticsearch.index'),
+              "document_type" => p('logstash_parser.elasticsearch.index_type'),
+              "manage_template" => false
+            }
+            if p('logstash_parser.elasticsearch.idle_flush_time', nil)
+              options['idle_flush_time'] = p('logstash_parser.elasticsearch.idle_flush_time')
+            end
+            if p('logstash_parser.elasticsearch.document_id', nil)
+              options['document_id'] = p('logstash_parser.elasticsearch.document_id')
+            end
+            if p('logstash_parser.elasticsearch.routing', nil)
+              options['routing'] = p('logstash_parser.elasticsearch.routing')
+            end
+            output['options'] = options.merge(output['options'])
+          %>
+      <% end %>
+      <% output['options'].each do | k, v | %>
+        <%= k %> => <%= v.inspect %>
+      <% end %>
+      }
+  <% end %>
+  }
 }

--- a/packages/watchdog/packaging
+++ b/packages/watchdog/packaging
@@ -1,0 +1,1 @@
+cp -r watchdog/* "${BOSH_INSTALL_TARGET}"

--- a/packages/watchdog/spec
+++ b/packages/watchdog/spec
@@ -1,0 +1,7 @@
+---
+name: watchdog
+
+dependencies: []
+
+files:
+- watchdog/**/*

--- a/src/logsearch-config/spec/logstash-templates/input_and_output/compile.yml
+++ b/src/logsearch-config/spec/logstash-templates/input_and_output/compile.yml
@@ -28,3 +28,7 @@ template:
     - name: "outputs - elasticsearch properties"
       config: "input_and_output/test_outputs_elasticsearch_required_properties-config.yml"
       destination: "target/input_and_output-test_outputs_elasticsearch_required_properties.conf"
+
+    - name: "watchdog"
+      config: "input_and_output/test_watchdog-config.yml"
+      destination: "target/input_and_output-test_watchdog.conf"

--- a/src/logsearch-config/spec/logstash-templates/input_and_output/test_default-config.yml
+++ b/src/logsearch-config/spec/logstash-templates/input_and_output/test_default-config.yml
@@ -5,6 +5,9 @@ properties:
   logstash_ingestor:
     syslog:
       port: 5514
+    watchdog:
+      enable: false
+      interval: 10
   logstash_parser:
     debug: false
     outputs: [ { plugin: "elasticsearch", options: {} } ]

--- a/src/logsearch-config/spec/logstash-templates/input_and_output/test_enabled_debug-config.yml
+++ b/src/logsearch-config/spec/logstash-templates/input_and_output/test_enabled_debug-config.yml
@@ -5,6 +5,9 @@ properties:
   logstash_ingestor:
     syslog:
       port: 5514
+    watchdog:
+      enable: false
+      interval: 10
   logstash_parser:
     debug: true
     outputs: [ { plugin: "elasticsearch", options: {} } ]

--- a/src/logsearch-config/spec/logstash-templates/input_and_output/test_enabled_debug-expected.conf
+++ b/src/logsearch-config/spec/logstash-templates/input_and_output/test_enabled_debug-expected.conf
@@ -17,10 +17,12 @@ output {
         codec => "json"
     }
 
+  if [@type] != "heartbeat" {
     elasticsearch {
         hosts => ["127.0.0.1:9200"]
         index => "logs-%{[@metadata][index]}-%{+YYYY.MM.dd}"
         document_type => "%{@type}"
         manage_template => false
     }
+  }
 }

--- a/src/logsearch-config/spec/logstash-templates/input_and_output/test_inputs-config.yml
+++ b/src/logsearch-config/spec/logstash-templates/input_and_output/test_inputs-config.yml
@@ -5,6 +5,9 @@ properties:
   logstash_ingestor:
     syslog:
       port: 5514
+    watchdog:
+      enable: false
+      interval: 10
   logstash_parser:
     debug: false
     inputs: [ { plugin: "file", options: { path: "my/path/to/file" } }, { plugin: "syslog", options: { host: "127.0.0.1", port: 123} } ]

--- a/src/logsearch-config/spec/logstash-templates/input_and_output/test_inputs-expected.conf
+++ b/src/logsearch-config/spec/logstash-templates/input_and_output/test_inputs-expected.conf
@@ -21,10 +21,12 @@ input {
 }
 
 output {
+  if [@type] != "heartbeat" {
     elasticsearch {
         hosts => ["127.0.0.1:9200"]
         index => "logs-%{[@metadata][index]}-%{+YYYY.MM.dd}"
         document_type => "%{@type}"
         manage_template => false
     }
+  }
 }

--- a/src/logsearch-config/spec/logstash-templates/input_and_output/test_outputs-config.yml
+++ b/src/logsearch-config/spec/logstash-templates/input_and_output/test_outputs-config.yml
@@ -5,6 +5,9 @@ properties:
   logstash_ingestor:
     syslog:
       port: 5514
+    watchdog:
+      enable: false
+      interval: 10
   logstash_parser:
     debug: true
     outputs: [ { plugin: "elasticsearch", options: {} }, { plugin: "mongodb", options: { uri: "192.168.1.1", database: "logsearch", collection: "logs" } }, { plugin: "syslog", options: { host: "127.0.0.1", port: 123} } ]

--- a/src/logsearch-config/spec/logstash-templates/input_and_output/test_outputs-expected.conf
+++ b/src/logsearch-config/spec/logstash-templates/input_and_output/test_outputs-expected.conf
@@ -17,6 +17,7 @@ output {
         codec => "json"
     }
 
+  if [@type] != "heartbeat" {
     elasticsearch {
         hosts => ["127.0.0.1:9200"]
         index => "logs-%{[@metadata][index]}-%{+YYYY.MM.dd}"
@@ -34,4 +35,5 @@ output {
         host => "127.0.0.1"
         port => 123
     }
+  }
 }

--- a/src/logsearch-config/spec/logstash-templates/input_and_output/test_outputs_elasticsearch_all_properties-config.yml
+++ b/src/logsearch-config/spec/logstash-templates/input_and_output/test_outputs_elasticsearch_all_properties-config.yml
@@ -5,6 +5,9 @@ properties:
   logstash_ingestor:
     syslog:
       port: 5514
+    watchdog:
+      enable: false
+      interval: 10
   logstash_parser:
     debug: false
     outputs: [ { plugin: "elasticsearch", options: {} } ]

--- a/src/logsearch-config/spec/logstash-templates/input_and_output/test_outputs_elasticsearch_all_properties-expected.conf
+++ b/src/logsearch-config/spec/logstash-templates/input_and_output/test_outputs_elasticsearch_all_properties-expected.conf
@@ -13,6 +13,7 @@ input {
 
 output {
 
+  if [@type] != "heartbeat" {
     elasticsearch {
         hosts => ["127.0.0.1:9200"]
         index => "logs-%{[@metadata][index]}-%{+YYYY.MM.dd}"
@@ -22,5 +23,6 @@ output {
         idle_flush_time => 100
         routing => "%{some_field}"
     }
+  }
 
 }

--- a/src/logsearch-config/spec/logstash-templates/input_and_output/test_outputs_elasticsearch_required_properties-expected.conf
+++ b/src/logsearch-config/spec/logstash-templates/input_and_output/test_outputs_elasticsearch_required_properties-expected.conf
@@ -13,11 +13,13 @@ input {
 
 output {
 
+  if [@type] != "heartbeat" {
     elasticsearch {
         hosts => ["127.0.0.1:9200"]
         index => "logs-%{[@metadata][index]}-%{+YYYY.MM.dd}"
         document_type => "%{@type}"
         manage_template => false
     }
+  }
 
 }

--- a/src/logsearch-config/spec/logstash-templates/input_and_output/test_outputs_no_elasticsearch-config.yml
+++ b/src/logsearch-config/spec/logstash-templates/input_and_output/test_outputs_no_elasticsearch-config.yml
@@ -5,6 +5,9 @@ properties:
   logstash_ingestor:
     syslog:
       port: 5514
+    watchdog:
+      enable: false
+      interval: 10
   logstash_parser:
     debug: false
     outputs: [ { plugin: "mongodb", options: { uri: "192.168.1.1", database: "logsearch", collection: "logs" } }, { plugin: "syslog", options: { host: "127.0.0.1", port: 123} } ]

--- a/src/logsearch-config/spec/logstash-templates/input_and_output/test_outputs_no_elasticsearch-expected.conf
+++ b/src/logsearch-config/spec/logstash-templates/input_and_output/test_outputs_no_elasticsearch-expected.conf
@@ -12,7 +12,7 @@ input {
 }
 
 output {
-
+  if [@type] != "heartbeat" {
     mongodb {
         uri => "192.168.1.1"
         database => "logsearch"
@@ -23,4 +23,5 @@ output {
         host => "127.0.0.1"
         port => 123
     }
+  }
 }

--- a/src/logsearch-config/spec/logstash-templates/input_and_output/test_watchdog-config.yml
+++ b/src/logsearch-config/spec/logstash-templates/input_and_output/test_watchdog-config.yml
@@ -1,17 +1,19 @@
 # --
-# Only required "elasticsearch" properties are set.
+# Required properties are set + default values (see "parser" job spec for default values).
 # --
 properties:
   logstash_ingestor:
     syslog:
       port: 5514
     watchdog:
-      enable: false
+      enable: true
       interval: 10
   logstash_parser:
     debug: false
     outputs: [ { plugin: "elasticsearch", options: {} } ]
     elasticsearch:
+      document_id: ~
       index: "logs-%{[@metadata][index]}-%{+YYYY.MM.dd}"
       index_type: "%{@type}"
+      idle_flush_time: 100
       data_hosts: [127.0.0.1]

--- a/src/logsearch-config/spec/logstash-templates/input_and_output/test_watchdog-expected.conf
+++ b/src/logsearch-config/spec/logstash-templates/input_and_output/test_watchdog-expected.conf
@@ -9,9 +9,20 @@ input {
     host => "0.0.0.0"
     port => "5514"
   }
+  heartbeat {
+    id => "watchdog_heartbeat"
+    type => "heartbeat"
+    message => "heartbeat"
+    interval => 10
+  }
 }
 
 output {
+  if [@type] == "heartbeat" {
+    exec {
+      command => "touch /var/vcap/sys/run/ingestor_syslog/ingestor_syslog.watchdog"
+    }
+  }
   if [@type] != "heartbeat" {
     elasticsearch {
       hosts => ["127.0.0.1:9200"]

--- a/src/watchdog/bin/watchdog
+++ b/src/watchdog/bin/watchdog
@@ -1,0 +1,70 @@
+#!/bin/sh
+
+# Usage: watchdog <target job name> <max age in seconds> <kill command>
+#
+# This script watches a watchdog timer file.  If the file's timestamp ever gets
+# older than the given max age, the kill command is run.
+#
+# Various settings can be overridden using environment variables, e.g.:
+# BACKOFF_TIME_SECS=1800 watchdog foo_job 10 '/var/vcap/job/foo_job/bin/foo_job_ctl stop'
+#
+# The idea is that the target program should update the timer file at regular
+# intervals.  If it fails to do that, the watchdog kills it so that monit can
+# restart it.
+#
+# There's a risk to doing this naively.  If there are multiple replicated
+# servers under heavy load, and one gets slightly overloaded and is too slow to
+# update its watchdog timer, killing it could trigger a cascading failure as
+# extra load gets shifted to other servers while it restarts.
+#
+# It's recommended to avoid this two ways.  First, make the max age a multiple
+# of the timer update time so that a kill isn't triggered on overload.  Second,
+# make sure BACKOFF_TIME_SECS is set to a value that's much longer than the
+# startup time.  This prevents the script from repeatedly restarting a server
+# when it's obviously not helping.
+
+set -eu
+
+TARGET="$1"
+MAX_AGE_SECS="$2"
+KILL_CMD="$3"
+: ${STARTUP_TIME_SECS=10}
+: ${BACKOFF_TIME_SECS=3600}
+: ${RUN_DIR="/var/vcap/sys/run/${TARGET}"}
+: ${WATCHDOG_TIMER="${RUN_DIR}/${TARGET}.watchdog"}
+
+log() {
+  echo "$(date): $1"
+}
+
+log "Watchdog starting"
+log "Target: ${TARGET}"
+log "Watchdog timer file: ${WATCHDOG_TIMER}"
+log "Max age: ${MAX_AGE_SECS} seconds"
+
+# This temporary file is used for doing timestamp comparisons.
+# Kind of hacky, but simple and works.
+BENCHMARK="$(mktemp)"
+trap 'rm -f "${BENCHMARK}"' EXIT
+
+while true
+do
+  sleep "${MAX_AGE_SECS}"
+  TARGET_PID="$(cat "${RUN_DIR}/${TARGET}.pid")"
+  # Get the process uptime, or just use 0 as a dummy value if the process is missing and let monit deal with it.
+  UPTIME_SECS="$(ps -o etimes= -p "${TARGET_PID}" || echo 0)"
+
+  if [ "${UPTIME_SECS}" -gt "${STARTUP_TIME_SECS}" ]
+  then
+    touch -d "${MAX_AGE_SECS} seconds ago" "${BENCHMARK}"
+    if [ "${WATCHDOG_TIMER}" -ot "${BENCHMARK}" ]
+    then
+      log "${TARGET} watchdog timer file stale ($(stat -c %y "${WATCHDOG_TIMER}") older than $(stat -c %y "${BENCHMARK}")"
+      log "Running ${KILL_CMD}"
+      sh -c "${KILL_CMD}"
+      log "Sleeping for ${BACKOFF_TIME_SECS} seconds before checking again"
+      sleep "${BACKOFF_TIME_SECS}"
+      log "Waking up"
+    fi
+  fi
+done


### PR DESCRIPTION
We had some stability issues with Logstash in our environment.
Occassionally Logstash would deadlock, and Monit wouldn't detect it
because it only checks if the process is still running.  We needed a way
to minimise the loss of production logs while we were debugging and
fixing the issue, so I added this watchdog timer.

I originally tried implementing it with some extra checks in
Monit, but ended up adding a separate monitoring job because Monit
doesn't support the kind of logic that's needed (at least not in the
very old version that's running on the standard BOSH Linux stemcells).