### PR TITLE
Explicitly set the subscription ID for the archiver to be different to that used by the ingestor

### DIFF
--- a/deployment/operations/archiver-syslog.yml
+++ b/deployment/operations/archiver-syslog.yml
@@ -19,6 +19,7 @@
           cloudfoundry:
             firehose_client_id: firehose-to-syslog
             firehose_client_secret: ((firehose_client_secret))
+            firehose_subscription_id: logsearch-archiver
             skip_ssl_validation: false
           syslog:
             host: 127.0.0.1


### PR DESCRIPTION
Otherwise logs are load balanced rather than available to both jobs