### PR TITLE
AWS Elasticsearch Service support for curator

### DIFF
--- a/jobs/curator/spec
+++ b/jobs/curator/spec
@@ -41,6 +41,43 @@ properties:
   curator.elasticsearch.port:
     description: Port address of elasticsearch host to proxy requests for (eg, 9200)
     default: 9200
+  curator.elasticsearch.url_prefix:
+    description: |
+      In some cases you may be obliged to connect to your Elasticsearch cluster through 
+      a proxy of some kind. There may be a URL prefix before the API URI items, 
+      e.g. http://example.com/elasticsearch/ as opposed to http://localhost:9200. 
+      In such a case, set the url_prefix to the appropriate value, elasticsearch in this example.
+    default: ''
+  curator.elasticsearch.use_ssl:
+    description: If access to your Elasticsearch instance is protected by SSL encryption, you must use set use_ssl to true.
+    default: 'false'  
+  curator.elasticsearch.ssl_certificate:
+    description: This should be a file path to your CA certificate, or left empty.
+    default: ''  
+  curator.elasticsearch.client_cert:
+    description: This should be a file path to a client certificate (public key), or left empty.
+    default: ''  
+  curator.elasticsearch.client_key:
+    description: This should be a file path to a client key (private key), or left empty.  
+    default: '' 
+  curator.elasticsearch.ssl_no_validate:
+    description: |
+      If access to your Elasticsearch instance is protected by 
+      SSL encryption, you may set ssl_no_validate to True to 
+      disable SSL certificate verification.
+    default: 'false'
+  curator.elasticsearch.http_auth:
+    description: This setting allows basic HTTP authentication to an Elasticsearch instance (e.g. user:pass).
+    default: ''  
+  curator.elasticsearch.timeout:
+    description: HTTP timeout for elasticsearch requests
+    default: '30'  
+  curator.elasticsearch.master_only:
+    description: |
+      In some situations, primarily with automated deployments, it makes sense to install Curator 
+      on every node. But you wouldn’t want it to run on each node. By setting master_only to True, this 
+      is possible. It tests for, and will only continue running on the node that is the elected master.
+    default: 'false'
   curator.purge_logs.unit:
     description: "One of the following values: seconds, minutes, hours, days, weeks, months, years"
     default: "days"

--- a/jobs/curator/templates/config/config.yml.erb
+++ b/jobs/curator/templates/config/config.yml.erb
@@ -1,6 +1,16 @@
 <%
   elasticsearch_hosts = nil
   elasticsearch_port = nil
+  elasticsearch_url_prefix = nil
+  elasticsearch_use_ssl = 'false'
+  elasticsearch_ssl_cert = nil
+  elasticsearch_ssl_client_cert = nil
+  elasticsearch_ssl_client_key = nil
+  elasticsearch_ssl_no_validate = 'false'
+  elasticsearch_http_auth = nil
+  elasticsearch_timeout = 30
+  elasticsearch_master_only = 'false'
+
   if_link("elasticsearch") { |elasticsearch_link|
     elasticsearch_hosts = elasticsearch_link.instances.map { |instance| instance.address }
     elasticsearch_port = elasticsearch_link.p("elasticsearch.port")
@@ -11,23 +21,51 @@
   unless elasticsearch_port
     elasticsearch_port = p("curator.elasticsearch.port")
   end
+  unless elasticsearch_url_prefix
+    elasticsearch_url_prefix = p("curator.elasticsearch.url_prefix")
+  end
+  if_p("curator.elasticsearch.use_ssl") do |use_ssl| 
+    elasticsearch_use_ssl = use_ssl
+  end
+  unless elasticsearch_ssl_cert
+    elasticsearch_ssl_cert = p("curator.elasticsearch.ssl_certificate")
+  end    
+  unless elasticsearch_ssl_client_cert
+    elasticsearch_ssl_client_cert = p("curator.elasticsearch.client_cert")
+  end  
+  unless elasticsearch_ssl_client_key
+    elasticsearch_ssl_client_key = p("curator.elasticsearch.client_key")
+  end  
+  if_p("curator.elasticsearch.ssl_no_validate") do |ssl_no_validate|
+    elasticsearch_ssl_no_validate = ssl_no_validate
+  end
+  unless elasticsearch_http_auth
+    elasticsearch_http_auth = p("curator.elasticsearch.http_auth")
+  end      
+  if_p("curator.elasticsearch.timeout") do |timeout|
+    elasticsearch_timeout = timeout
+  end 
+  if_p("curator.elasticsearch.master_only") do |master_only| 
+    elasticsearch_master_only = master_only
+  end
+
 %>
 ---
 client:
   hosts: <%= elasticsearch_hosts %>
   port: <%= elasticsearch_port %>
-  url_prefix:
-  use_ssl: False
-  certificate:
-  client_cert:
-  client_key:
-  ssl_no_validate: False
-  http_auth:
-  timeout: 30
-  master_only: False
+  url_prefix: <%= elasticsearch_url_prefix %>
+  use_ssl: <%= elasticsearch_use_ssl %>
+  certificate: <%= elasticsearch_ssl_cert %>
+  client_cert: <%= elasticsearch_ssl_client_cert %>
+  client_key: <%= elasticsearch_ssl_client_key %>
+  ssl_no_validate: <%= elasticsearch_ssl_no_validate %>
+  http_auth: <%= elasticsearch_http_auth %>
+  timeout: <%= elasticsearch_timeout %>
+  master_only: <%= elasticsearch_master_only %>
 
 logging:
   loglevel: <%= p('curator.loglevel') %>
-  logfile:
+  logfile: '/var/vcap/sys/log/curator/curator.stdout.log'
   logformat: <%= p('curator.logformat') %>
   blacklist: ['elasticsearch', 'urllib3']


### PR DESCRIPTION
Hi,

This PR adds the ability to set host and SSL parameters to enable operators to deploy a subset of this release with the parser, router and curator while shipping all the logs to AWS Elasticsearch Service. I started rolling out this out for cerebro, but I'll submit those changes in a separate PR.

For context: In our deployment, we have a CF deployment on AWS and we prefer shipping our logs to AWS Elasticsearch Service instead of running elasticsearch as part of the bosh release.

I'd be happy to iterate on this or answer any questions that come up.

Thanks!
Kit