### PR TITLE
Fix nc command line

### DIFF
--- a/jobs/elasticsearch/templates/bin/post-start.erb
+++ b/jobs/elasticsearch/templates/bin/post-start.erb
@@ -8,7 +8,7 @@ echo "Waiting <%= p("elasticsearch.health.connect_timeout") %>s for elasticsearc
 elapsed=0
 until [ $elapsed -ge <%= p("elasticsearch.health.connect_timeout") %> ]
 do
-  nc -4 -z -v localhost 9200 2>&1 && break
+  nc -4 -v localhost 9200 < /dev/null 2>&1 && break
   elapsed=$[$elapsed+<%= p("elasticsearch.health.connect_interval") %>]
   sleep <%= p("elasticsearch.health.connect_interval") %>
 done


### PR DESCRIPTION
netcat "-z" option does not exist dor RedHat/CentOS distributions. Thus, Elasticsearch post-start script fails and Bosh deployment fails.
Patch successfully tested on both Ubuntu Trustry and CentOS 7 Bosh stemcells.  