### PR TITLE
adds heap_percentage parameter for ingestor_syslog and elasticsearch …

### DIFF
--- a/jobs/elasticsearch/spec
+++ b/jobs/elasticsearch/spec
@@ -49,6 +49,9 @@ properties:
     default: []
   elasticsearch.heap_size:
     description: sets jvm heap sized
+  elasticsearch.heap_percentage:
+    description: The percentage value used in the calculation to set the heap size.
+    default: 46
   elasticsearch.path_repo:
     description: |
       Shared file system to store snapshots.

--- a/jobs/elasticsearch/templates/bin/elasticsearch_ctl
+++ b/jobs/elasticsearch/templates/bin/elasticsearch_ctl
@@ -13,8 +13,7 @@ export LANG=en_US.UTF-8
 export <%= k %>=<%= v %>
 <% end %>
 
-export HEAP_SIZE=$((( $( cat /proc/meminfo | grep MemTotal | awk '{ print $2 }' ) * 46 ) / 100 ))K
-
+export HEAP_SIZE=$((( $( cat /proc/meminfo | grep MemTotal | awk '{ print $2 }' ) * <%= p("elasticsearch.heap_percentage") %> ) / 100 ))K
 <% if_p('elasticsearch.heap_size') do |heap_size| %>
   HEAP_SIZE=<%= heap_size %>
 <% end %>

--- a/jobs/ingestor_syslog/spec
+++ b/jobs/ingestor_syslog/spec
@@ -36,6 +36,9 @@ provides:
 properties:
   logstash.heap_size:
     description: sets jvm heap sized
+  logstash.heap_percentage:
+    description: The percentage value used in the calculation to set the heap size.
+    default: 46
   logstash.metadata_level:
     description: "Whether to include additional metadata throughout the event lifecycle. NONE = disabled, DEBUG = fully enabled"
     default: "NONE"

--- a/jobs/ingestor_syslog/templates/bin/ingestor_syslog_ctl
+++ b/jobs/ingestor_syslog/templates/bin/ingestor_syslog_ctl
@@ -31,7 +31,7 @@ export LOGSTASH_WORKERS=<%= p('logstash_parser.workers') %>
 <% end %>
 export TIMECOP_REJECT_GREATER_THAN_HOURS=<%= p('logstash_parser.timecop.reject_greater_than_hours') %>
 export TIMECOP_REJECT_LESS_THAN_HOURS=<%= p('logstash_parser.timecop.reject_less_than_hours') %>
-export HEAP_SIZE=$((( $( cat /proc/meminfo | grep MemTotal | awk '{ print $2 }' ) * 46 ) / 100 ))K
+export HEAP_SIZE=$((( $( cat /proc/meminfo | grep MemTotal | awk '{ print $2 }' ) * <%= p("logstash.heap_percentage") %> ) / 100 ))K
 <% if_p('logstash.heap_size') do |heap_size| %>
 HEAP_SIZE=<%= heap_size %>
 <% end %>


### PR DESCRIPTION
…jobs

This pull request enables the heap_size of the ingestor_syslog and elasticsearch jobs to be set via a percentage. The default is set to the original 46%

Signed-off-by: Kieran Robinson <krobn@allstate.com>