### PR TITLE
Added content type to curl requests

### DIFF
--- a/jobs/elasticsearch/templates/bin/drain.erb
+++ b/jobs/elasticsearch/templates/bin/drain.erb
@@ -6,6 +6,7 @@ set -e
 # disable allocations before bringing down data nodes
 
 curl -s -X PUT localhost:9200/_all/_settings \
+  -H 'Content-Type: application/json' \
   -d '{"settings": {"index.unassigned.node_left.delayed_timeout": "<%= p("elasticsearch.recovery.delay_allocation_restart") %>"}}' \
   > /dev/null
 

--- a/jobs/elasticsearch/templates/bin/post-deploy.erb
+++ b/jobs/elasticsearch/templates/bin/post-deploy.erb
@@ -4,10 +4,12 @@ set -e
 
 <% if p('elasticsearch.cloud.aws.bucket') != '' and p('elasticsearch.node.allow_master') and spec.bootstrap %>
 curl -X PUT -s localhost:9200/_snapshot/<%= p('elasticsearch.snapshots.repository') %> \
+  -H 'Content-Type: application/json' \
   -d '{"type": "s3", "settings": {"bucket": "<%= p('elasticsearch.cloud.aws.bucket') %>"}}'
 <% end %>
 
 <% if p('elasticsearch.path_repo') != '' and p('elasticsearch.node.allow_master') and spec.bootstrap %>
 curl -X PUT -s localhost:9200/_snapshot/<%= p('elasticsearch.snapshots.repository') %> \
+  -H 'Content-Type: application/json' \
   -d '{"type": "fs", "settings": {"location": "<%= p('elasticsearch.path_repo') %>/<%= p('elasticsearch.snapshots.repository') %>", "compress": true}}'
 <% end %>

--- a/jobs/elasticsearch/templates/bin/post-start.erb
+++ b/jobs/elasticsearch/templates/bin/post-start.erb
@@ -48,6 +48,7 @@ rm ${out}
 
 <% if p("elasticsearch.node.allow_data") %>
 curl -X PUT -s localhost:9200/_all/_settings \
+  -H 'Content-Type: application/json' \
   -d '{"settings": {"index.unassigned.node_left.delayed_timeout": "<%= p("elasticsearch.recovery.delay_allocation") %>"}}'
 <% end %> 
 


### PR DESCRIPTION
Elasticsearch endpoint requires content type header for all requests that contain the content (in general json). The requirerement is described here:
https://www.elastic.co/blog/strict-content-type-checking-for-elasticsearch-rest-requests

Issue is hard to track in BOSH, but in logs of elasticsearch_data it is displayed as:

`{"error":"Content-Type header [application/x-www-form-urlencoded] is not supported","status":406}Node failed to join the cluster`

This applies to post_start script and same issue is reproducible from the VM using the request:
`curl -X PUT -s localhost:9200/_all/_settings  -d '{"settings":{"index.unassigned.node_left.delayed_timeout": "0"}}'`

@axelaris as discussed in https://github.com/cloudfoundry-community/logsearch-boshrelease/pull/125