### PR TITLE
Enables codec entries for outputs in the ingestor_syslog job.

### DIFF
--- a/jobs/ingestor_syslog/templates/config/input_and_output.conf.erb
+++ b/jobs/ingestor_syslog/templates/config/input_and_output.conf.erb
@@ -72,7 +72,11 @@ output {
             %>
         <% end %>
         <% output['options'].each do | k, v | %>
-          <%= k %> => <%= v.inspect %>
+          <% if k == 'codec' %>
+            <%= k %> => <%= v %>
+          <% else %>
+            <%= k %> => <%= v.inspect %>
+          <% end %>
         <% end %>
         }
     <% end %>


### PR DESCRIPTION
When setting the property ingestor_syslog.ouputs with additional logstash outputs the codec field was being set to a string. According to the documentation the codec field value for any available output is an object and not a string or integer.

https://www.elastic.co/guide/en/logstash/current/codec-plugins.html