### PR TITLE
Use elasticsearch_data nodes in Logstash output

### DIFF
--- a/deployment/logsearch-deployment.yml
+++ b/deployment/logsearch-deployment.yml
@@ -97,6 +97,9 @@ instance_groups:
       ingestor: nil
     properties:
       logstash_parser:
+        elasticsearch:
+          data_hosts:
+          - 127.0.0.1
         filters:
         - monitor: /var/vcap/packages/logsearch-config/logstash-filters-monitor.conf
   - name: curator
@@ -263,10 +266,15 @@ instance_groups:
       elasticsearch: {from: elasticsearch_master}
   - name: ingestor_syslog
     release: logsearch
+    consumes:
+      elasticsearch: {from: elasticsearch_data}
     provides:
       ingestor: {as: ingestor_link}
     properties:
       logstash_parser:
+        elasticsearch:
+          data_hosts:
+          - 127.0.0.1
         deployment_dictionary:
           - /var/vcap/packages/logsearch-config/deployment_lookup.yml
   - name: syslog_forwarder

--- a/deployment/logsearch-deployment.yml
+++ b/deployment/logsearch-deployment.yml
@@ -268,8 +268,6 @@ instance_groups:
       elasticsearch: {from: elasticsearch_master}
   - name: ingestor_syslog
     release: logsearch
-    consumes:
-      elasticsearch: {from: elasticsearch_data}
     provides:
       ingestor: {as: ingestor_link}
     properties:

--- a/deployment/logsearch-deployment.yml
+++ b/deployment/logsearch-deployment.yml
@@ -93,7 +93,7 @@ instance_groups:
   - name: ingestor_syslog
     release: logsearch
     consumes:
-     elasticsearch: nil
+      elasticsearch: nil
     provides:
       syslog_forwarder: {as: cluster_monitor}
       ingestor: nil
@@ -268,6 +268,8 @@ instance_groups:
       elasticsearch: {from: elasticsearch_master}
   - name: ingestor_syslog
     release: logsearch
+    consumes:
+      elasticsearch: nil
     provides:
       ingestor: {as: ingestor_link}
     properties:

--- a/deployment/logsearch-deployment.yml
+++ b/deployment/logsearch-deployment.yml
@@ -92,6 +92,8 @@ instance_groups:
         - index-mappings: /var/vcap/jobs/elasticsearch_config/index-templates/index-mappings.json
   - name: ingestor_syslog
     release: logsearch
+    consumes:
+     elasticsearch: nil
     provides:
       syslog_forwarder: {as: cluster_monitor}
       ingestor: nil

--- a/deployment/operations/cloudfoundry.yml
+++ b/deployment/operations/cloudfoundry.yml
@@ -75,9 +75,8 @@
   - logsearch-for-cf: /var/vcap/packages/logsearch-config-logstash-filters/logstash-filters-default.conf
 
 - type: replace
-  path: /instance_groups/name=ingestor/jobs/name=ingestor_syslog/properties/logstash_parser/elasticsearch?
-  value:
-    index: logs-%{[@metadata][index]}-v6-%{+YYYY.MM.dd}
+  path: /instance_groups/name=ingestor/jobs/name=ingestor_syslog/properties/logstash_parser/elasticsearch?/index?
+  value: logs-%{[@metadata][index]}-v6-%{+YYYY.MM.dd}
 
 - type: replace
   path: /instance_groups/name=ingestor/jobs/-

--- a/deployment/operations/ingestor-forward-to-elasticsearch-data.yml
+++ b/deployment/operations/ingestor-forward-to-elasticsearch-data.yml
@@ -1,0 +1,22 @@
+- type: replace
+  path: /instance_groups/name=cluster_monitor/jobs/name=ingestor_syslog/consumes?
+  value:
+    elasticsearch: nil
+
+- type: replace
+  path: /instance_groups/name=elasticsearch_data/jobs/name=elasticsearch/provides?
+  value:
+    elasticsearch:
+      as: elasticsearch_data
+
+- type: remove
+  path: /instance_groups/name=ingestor/jobs/name=elasticsearch
+
+- type: replace
+  path: /instance_groups/name=ingestor/jobs/name=ingestor_syslog/consumes?
+  value:
+    elasticsearch:
+      from: elasticsearch_data
+
+- type: remove
+  path: /instance_groups/name=ingestor/jobs/name=ingestor_syslog/properties?/logstash_parser?/elasticsearch?/data_hosts?

--- a/jobs/ingestor_syslog/spec
+++ b/jobs/ingestor_syslog/spec
@@ -34,6 +34,11 @@ provides:
   properties:
   - logstash_ingestor.syslog.port
 
+consumes:
+- name: elasticsearch
+  type: elasticsearch
+  optional: true
+
 properties:
   logstash.heap_size:
     description: sets jvm heap sized
@@ -156,7 +161,6 @@ properties:
     description: "The routing to be used when indexing a document."
   logstash_parser.elasticsearch.data_hosts:
     description: The list of elasticsearch data node IPs
-    default: [127.0.0.1]
   logstash_parser.timecop.reject_greater_than_hours:
     description: "Logs with timestamps greater than this many hours in the future won't be parsed and will get tagged with fail/timecop"
     default: 1

--- a/jobs/ingestor_syslog/templates/bin/ingestor_syslog_ctl
+++ b/jobs/ingestor_syslog/templates/bin/ingestor_syslog_ctl
@@ -6,9 +6,17 @@ set -u # report the usage of uninitialized variables
 # Setup env vars and folders for the webapp_ctl script
 source /var/vcap/jobs/ingestor_syslog/helpers/ctl_setup.sh 'ingestor_syslog'
 
+<%
+  es_host = nil
+  if_p("logstash_parser.elasticsearch.data_hosts") { |hosts| es_host = hosts.first }
+  unless es_host
+    es_host =  link("elasticsearch").instances.first.address
+  end
+%>
+
 function wait_for_template {
   local template_name="$1"
-  local MASTER_URL="<%= p("logstash_parser.elasticsearch.data_hosts").first %>:9200"
+  local MASTER_URL="<%= es_host %>:9200"
 
   set +e
   while true;  do

--- a/jobs/ingestor_syslog/templates/config/input_and_output.conf.erb
+++ b/jobs/ingestor_syslog/templates/config/input_and_output.conf.erb
@@ -43,6 +43,14 @@ input {
   <% end %>
 }
 
+<%
+  es_output_hosts = nil
+  if_p("logstash_parser.elasticsearch.data_hosts") { |hosts| es_output_hosts = hosts.map { |ip| "#{ip}:9200" }.join(',') }
+  unless es_output_hosts
+    es_output_hosts =  link("elasticsearch").address
+  end
+%>
+
 output {
     <% if p("logstash_parser.debug") %>
         stdout {
@@ -55,7 +63,7 @@ output {
         <% if 'elasticsearch' == output['plugin'] %>
             <%
               options = {
-                "hosts" => [ p('logstash_parser.elasticsearch.data_hosts').map { |ip| "#{ip}:9200" }.join(',') ],
+                "hosts" => [ es_output_hosts ],
                 "index" => p('logstash_parser.elasticsearch.index'),
                 "manage_template" => false
               }


### PR DESCRIPTION
Hey! This PR changes the default hosts configuration in logstash elasticsearch output. Instead of collocating ElasticSearch and Logstash on the same VM we can point Logstash output plugin to the DNS name of ElasticSearch data nodes. This will decrease the amount of RAM used by Ingestor instances, check the graph below:

![Ingestor Memory Usage](https://i.imgur.com/UOkKKLL.png)

I will also create a separate PR which will allow to configure Elasticsearch coordinating nodes in a high load environments.

/cc @pommi @diogomatsubara