### PR TITLE
Elastic port incorrectly changed to Cerebro port

### DIFF
--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -199,7 +199,7 @@ backend elastic
     mode http
     balance roundrobin
     <% elasticsearch_hosts.each_with_index do |ip, index| %>
-    server elastic<%= index %> <%= ip %>:9000 check inter 1000
+    server elastic<%= index %> <%= ip %>:9200 check inter 1000
     <% end %>
 
 


### PR DESCRIPTION
When Cerebro was introduced the HAProxy template was changed so that the elastic backend port used the Cerebro port. This is not correct since the elastic backend is there for making the Cluster HTTP module exposed and this is on port 9200.