### PR TITLE
Ensure that Cerebro opsfile uses correct route_registrar job

### DIFF
--- a/deployment/operations/cerebro.yml
+++ b/deployment/operations/cerebro.yml
@@ -15,7 +15,7 @@
   path: /instance_groups/name=elasticsearch_master/jobs/-
   value:
     name: route_registrar
-    release: logsearch-for-cloudfoundry
+    release: routing
     consumes:
       nats: {from: nats, deployment: cf}
     properties:
@@ -26,6 +26,10 @@
           registration_interval: 60s
           uris:
           - "cerebro.((system_domain))"
+
+- type: replace
+  path: /instance_groups/name=elasticsearch_master/jobs/name=bpm?/release
+  value: bpm
 
 # --- define secrets for cerebro
 - type: replace


### PR DESCRIPTION
Hi Logsearch Bosh Release team,

It looks like you forgot to update the Cerebro opsfile when switching the `route_registrar` job to use the routing release. This PR updates the cerebro.yml opsfile to use the correct release, matching the [cloudfoundry.yml opsfile](https://github.com/cloudfoundry-community/logsearch-boshrelease/blob/develop/deployment/operations/cloudfoundry.yml#L145). I've verified that manifests generated with the updated opsfile work as expected and fix the `Error: Job 'route_registrar' not found in Template table` error you get when it uses the previous `logsearch-for-cloudfoundry` release.

cheers,

Pete