### PR TITLE
Ops: firehose-to-syslog password taken from CF deployment

### DIFF
--- a/deployment/operations/cf/add-firehose-to-syslog-uaa-clients.yml
+++ b/deployment/operations/cf/add-firehose-to-syslog-uaa-clients.yml
@@ -1,4 +1,5 @@
 # Apply to your cf-deployment based Cloud Foundry
+# Use it with: ../set-firehose-to-syslog-password.yml
 
 # UAA client for firehose-to-syslog
 - type: replace

--- a/deployment/operations/set-firehose-to-syslog-password.yml
+++ b/deployment/operations/set-firehose-to-syslog-password.yml
@@ -1,0 +1,5 @@
+# Use it with: cf/add-firehose-to-syslog-uaa-clients.yml
+
+- type: replace
+  path: /instance_groups/name=ingestor/jobs/name=ingestor_cloudfoundry-firehose/properties/cloudfoundry/firehose_client_secret?
+  value: ((uaa_clients_firehose_to_syslog_secret))


### PR DESCRIPTION
Due to UAA firehose client is recreated by:

- the [logsearch-for-cloudfoundry operation](https://github.com/cloudfoundry-community/logsearch-for-cloudfoundry/blob/develop/jobs/ingestor_cloudfoundry-firehose/templates/bin/pre-start.erb) 
- and the [CF UAA Operation](https://github.com/cloudfoundry-community/logsearch-boshrelease/blob/develop/deployment/operations/cf/add-firehose-to-syslog-uaa-clients.yml)

the `uaa_clients_firehose_to_syslog_secret` should be used in both deployments.

Issue: https://github.com/cloudfoundry-community/logsearch-for-cloudfoundry/issues/333