### PR TITLE
Enable HAProxy httplog option for Kibana access logs

### DIFF
--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -136,6 +136,7 @@ backend ingestors-relp
 
 frontend kibana-in
     mode http
+    option httplog
 
     bind :<%= p("haproxy.kibana.inbound_port.http") %>
     <% if properties.haproxy.ssl_pem and properties.haproxy.kibana.enable_ssl == true %>
@@ -158,6 +159,7 @@ backend kibana
 
 frontend cluster_monitor-in
     mode http
+    option httplog
 
     <% if properties.haproxy.ssl_pem %>
     bind :<%= p("haproxy.cluster_monitor.inbound_port") %> ssl crt /var/vcap/jobs/haproxy/config/cert.pem no-sslv3


### PR DESCRIPTION
This improves the HAProxy log output format to include the HTTP method and path
https://cbonte.github.io/haproxy-dconv/1.7/configuration.html#4-option%20httplog

Example log:
11.217.33.72:50005 [05/Feb/2020:10:40:33.619] kibana-in~ kibana/kibana0 0/0/1/97/99 200 28881 - - ---- 18/6/0/1/0 0/0 "POST /elasticsearch/_msearch?rest_total_hits_as_int=true&ignore_throttled=true HTTP/1.1"

We have tested this by manually editing the HAProxy config file and restarting the monit process