### PR TITLE
Fix syslog_sd parsing

### DIFF
--- a/src/logsearch-config/src/logstash-filters/snippets/syslog_standard.conf
+++ b/src/logsearch-config/src/logstash-filters/snippets/syslog_standard.conf
@@ -41,7 +41,7 @@ if !("fail/syslog_standard/_grokparsefailure" in [tags]) {
         # structured-data
         if [syslog_sd] {
             grok {
-                match => [ "syslog_sd", "\[%{DATA:syslog_sd_id} (?<syslog_sd_params_raw]>[^\]]+)\]" ]
+                match => [ "syslog_sd", "\[%{DATA:syslog_sd_id} (?<syslog_sd_params_raw>[^\]]+)\]" ]
                 remove_field => [
                     "syslog_sd"
                 ]


### PR DESCRIPTION
Fixes #176 by fixing the `syslog_sd_raw` field capture name. Sorry for the two direct commits; I have admin rights in cf-community and thought I was pushing to my fork. I reverted my change because I wanted to get this reviewed.