### PR TITLE
Fix remove ls-router if not present

### DIFF
--- a/deployment/operations/push-cloudfoundry-kibana.yml
+++ b/deployment/operations/push-cloudfoundry-kibana.yml
@@ -2,7 +2,7 @@
   path: /instance_groups/name=kibana
 
 - type: remove
-  path: /instance_groups/name=ls-router
+  path: /instance_groups/name=ls-router?
 
 - type: replace
   path: /instance_groups/name=maintenance/jobs/-


### PR DESCRIPTION
Since the ls-router instance_group is optional this will allow using the push-cloudfoundry-kibana.yml if the ls-router is not present